### PR TITLE
feat(*): trigonometric functions: exp, log, sin, cos, tan, sinh, cosh…

### DIFF
--- a/algebra/archimedean.lean
+++ b/algebra/archimedean.lean
@@ -11,20 +11,18 @@ local infix ` • ` := add_monoid.smul
 
 variables {α : Type*}
 
-class floor_ring (α) extends linear_ordered_ring α :=
+class floor_ring (α) [linear_ordered_ring α] :=
 (floor : α → ℤ)
 (le_floor : ∀ (z : ℤ) (x : α), z ≤ floor x ↔ (z : α) ≤ x)
 
 instance : floor_ring ℤ :=
-{ floor := id, le_floor := λ _ _, by rw int.cast_id; refl,
-  ..linear_ordered_comm_ring.to_linear_ordered_ring ℤ }
+{ floor := id, le_floor := λ _ _, by rw int.cast_id; refl }
 
 instance : floor_ring ℚ :=
-{ floor := rat.floor, le_floor := @rat.le_floor,
-  ..linear_ordered_comm_ring.to_linear_ordered_ring ℚ }
+{ floor := rat.floor, le_floor := @rat.le_floor }
 
 section
-variable [floor_ring α]
+variables [linear_ordered_ring α] [floor_ring α]
 
 def floor : α → ℤ := floor_ring.floor
 
@@ -153,6 +151,29 @@ begin
 end
 
 end linear_ordered_ring
+
+section linear_ordered_field
+
+variables [linear_ordered_field α] [floor_ring α]
+
+lemma sub_floor_div_mul_nonneg (x : α) {y : α} (hy : 0 < y) :
+  0 ≤ x - ⌊x / y⌋ * y :=
+begin
+  conv in x {rw ← div_mul_cancel x (ne_of_lt hy).symm},
+  rw ← sub_mul,
+  exact mul_nonneg (sub_nonneg.2 (floor_le _)) (le_of_lt hy)
+end
+
+lemma sub_floor_div_mul_lt (x : α) {y : α} (hy : 0 < y) :
+  x - ⌊x / y⌋ * y < y :=
+sub_lt_iff_lt_add.2 begin
+  conv in y {rw ← one_mul y},
+  conv in x {rw ← div_mul_cancel x (ne_of_lt hy).symm},
+  rw ← add_mul,
+  exact (mul_lt_mul_right hy).2 (by rw add_comm; exact lt_floor_add_one _),
+end
+
+end linear_ordered_field
 
 instance : archimedean ℕ :=
 ⟨λ n m m0, ⟨n, by simpa only [mul_one, nat.smul_eq_mul] using nat.mul_le_mul_left n m0⟩⟩

--- a/algebra/group_power.lean
+++ b/algebra/group_power.lean
@@ -406,6 +406,9 @@ lemma pow_abs [decidable_linear_ordered_comm_ring α] (a : α) (n : ℕ) : (abs 
 by induction n with n ih; [exact (abs_one).symm,
   rw [pow_succ, pow_succ, ih, abs_mul]]
 
+lemma inv_pow' [discrete_field α] (a : α) (n : ℕ) : (a ^ n)⁻¹ = a⁻¹ ^ n :=
+by induction n; simp [*, pow_succ, mul_inv', mul_comm]
+
 lemma pow_inv [division_ring α] (a : α) : ∀ n : ℕ, a ≠ 0 → (a^n)⁻¹ = (a⁻¹)^n
 | 0     ha := inv_one
 | (n+1) ha := by rw [pow_succ, pow_succ', mul_inv_eq (pow_ne_zero _ ha) ha, pow_inv _ ha]
@@ -477,9 +480,11 @@ lemma pow_le_pow_of_le_one  {a : α} (h : 0 ≤ a) (ha : a ≤ 1)
 let ⟨k, hk⟩ := nat.exists_eq_add_of_le hij in
 by rw hk; exact pow_le_pow_of_le_one_aux h ha _ _
 
+lemma pow_le_one {x : α} : ∀ (n : ℕ) (h0 : 0 ≤ x) (h1 : x ≤ 1), x ^ n ≤ 1
+| 0     h0 h1 := le_refl (1 : α)
+| (n+1) h0 h1 := mul_le_one h1 (pow_nonneg h0 _) (pow_le_one n h0 h1)
 
 end linear_ordered_semiring
-
 theorem pow_two_nonneg [linear_ordered_ring α] (a : α) : 0 ≤ a ^ 2 :=
 by rw pow_two; exact mul_self_nonneg _
 

--- a/algebra/ordered_field.lean
+++ b/algebra/ordered_field.lean
@@ -162,9 +162,18 @@ by rw [inv_eq_one_div, lt_div_iff h₁]; simp [h₂]
 lemma inv_le_one {a : α} (ha : 1 ≤ a) : a⁻¹ ≤ 1 :=
 by rw [inv_eq_one_div]; exact div_le_of_le_mul (lt_of_lt_of_le zero_lt_one ha) (by simp *)
 
+lemma one_le_inv {x : α} (hx0 : 0 < x) (hx : x ≤ 1) : 1 ≤ x⁻¹ :=
+le_of_mul_le_mul_left (by simpa [mul_inv_cancel (ne.symm (ne_of_lt hx0))]) hx0
+
 lemma mul_self_inj_of_nonneg {a b : α} (a0 : 0 ≤ a) (b0 : 0 ≤ b) : a * a = b * b ↔ a = b :=
 (mul_self_eq_mul_self_iff a b).trans $ or_iff_left_of_imp $
 λ h, by subst a; rw [le_antisymm (neg_nonneg.1 a0) b0, neg_zero]
+
+lemma div_le_div_of_le_left {a b c : α} (ha : 0 ≤ a) (hb : 0 < b) (hc : 0 < c) (h : c ≤ b) :
+  a / b ≤ a / c :=
+by haveI := classical.dec_eq α; exact
+if ha0 : a = 0 then by simp [ha0]
+else (div_le_div_left (lt_of_le_of_ne ha (ne.symm ha0)) hb hc).2 h
 
 end linear_ordered_field
 

--- a/algebra/ordered_ring.lean
+++ b/algebra/ordered_ring.lean
@@ -83,6 +83,32 @@ lemma one_lt_mul {a b : α} (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=
 lemma mul_le_one {a b : α} (ha : a ≤ 1) (hb' : 0 ≤ b) (hb : b ≤ 1) : a * b ≤ 1 :=
 begin rw ← one_mul (1 : α), apply mul_le_mul; {assumption <|> apply zero_le_one} end
 
+lemma one_lt_mul_of_le_of_lt {a b : α} (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=
+calc 1 = 1 * 1 : by rw one_mul
+... < a * b : mul_lt_mul' ha hb zero_le_one (lt_of_lt_of_le zero_lt_one ha)
+
+lemma one_lt_mul_of_lt_of_le {a b : α} (ha : 1 < a) (hb : 1 ≤ b) : 1 < a * b :=
+calc 1 = 1 * 1 : by rw one_mul
+... < a * b : mul_lt_mul ha hb zero_lt_one (le_trans zero_le_one (le_of_lt ha))
+
+lemma mul_le_of_le_one_right {a b : α} (ha : 0 ≤ a) (hb1 : b ≤ 1) : a * b ≤ a :=
+calc a * b ≤ a * 1 : mul_le_mul_of_nonneg_left hb1 ha
+... = a : mul_one a
+
+lemma mul_le_of_le_one_left {a b : α} (hb : 0 ≤ b) (ha1 : a ≤ 1) : a * b ≤ b :=
+calc a * b ≤ 1 * b : mul_le_mul ha1 (le_refl b) hb zero_le_one
+... = b : one_mul b
+
+lemma mul_lt_one_of_nonneg_of_lt_one_left {a b : α}
+  (ha0 : 0 ≤ a) (ha : a < 1) (hb : b ≤ 1) : a * b < 1 :=
+calc a * b ≤ a : mul_le_of_le_one_right ha0 hb
+... < 1 : ha
+
+lemma mul_lt_one_of_nonneg_of_lt_one_right {a b : α}
+  (ha : a ≤ 1) (hb0 : 0 ≤ b) (hb : b < 1) : a * b < 1 :=
+calc a * b ≤ b : mul_le_of_le_one_left hb0 ha
+... < 1 : hb
+
 lemma mul_le_iff_le_one_left {a b : α} (hb : b > 0) : a * b ≤ b ↔ a ≤ 1 :=
 ⟨ λ h, le_of_not_lt (mt (lt_mul_iff_one_lt_left hb).2 (not_lt_of_ge h)),
   λ h, le_of_not_lt (mt (lt_mul_iff_one_lt_left hb).1 (not_lt_of_ge h)) ⟩

--- a/analysis/complex.lean
+++ b/analysis/complex.lean
@@ -83,7 +83,7 @@ let ⟨δ, δ0, Hδ⟩ := rat_mul_continuous_lemma abs ε0 r₁0 r₂0 in
 ⟨δ, δ0, λ a b h,
   let ⟨h₁, h₂⟩ := max_lt_iff.1 h in Hδ (H _ a.2).1 (H _ b.2).2 h₁ h₂⟩
 
-lemma continuous_mul : continuous (λp : ℂ × ℂ, p.1 * p.2) :=
+protected lemma continuous_mul : continuous (λp : ℂ × ℂ, p.1 * p.2) :=
 continuous_iff_tendsto.2 $ λ ⟨a₁, a₂⟩,
 tendsto_of_uniform_continuous_subtype
   (uniform_continuous_mul
@@ -97,8 +97,25 @@ tendsto_of_uniform_continuous_subtype
       (continuous_abs _ $ is_open_gt' _))
     ⟨lt_add_one (abs a₁), lt_add_one (abs a₂)⟩)
 
+lemma uniform_continuous_re : uniform_continuous re :=
+uniform_continuous_of_metric.2 (λ ε ε0, ⟨ε, ε0, λ _ _, lt_of_le_of_lt (abs_re_le_abs _)⟩)
+
+lemma continuous_re : continuous re := uniform_continuous_re.continuous
+
+lemma uniform_continuous_im : uniform_continuous im :=
+uniform_continuous_of_metric.2 (λ ε ε0, ⟨ε, ε0, λ _ _, lt_of_le_of_lt (abs_im_le_abs _)⟩)
+
+lemma continuous_im : continuous im := uniform_continuous_im.continuous
+
+lemma uniform_continuous_of_real : uniform_continuous of_real :=
+uniform_continuous_of_metric.2 (λ ε ε0, ⟨ε, ε0, λ _ _,
+  by rw [real.dist_eq, complex.dist_eq, of_real_eq_coe, of_real_eq_coe, ← of_real_sub, abs_of_real];
+    exact id⟩)
+
+lemma continuous_of_real : continuous of_real := uniform_continuous_of_real.continuous
+
 instance : topological_ring ℂ :=
-{ continuous_mul := continuous_mul, ..complex.topological_add_group }
+{ continuous_mul := complex.continuous_mul, ..complex.topological_add_group }
 
 instance : topological_semiring ℂ := by apply_instance
 

--- a/analysis/exponential.lean
+++ b/analysis/exponential.lean
@@ -1,0 +1,969 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes
+-/
+import analysis.real analysis.complex tactic.linarith data.complex.exponential
+
+open finset filter
+
+namespace complex
+
+lemma tendsto_exp_zero_one : tendsto exp (nhds 0) (nhds 1) :=
+tendsto_nhds_of_metric.2 $ λ ε ε0,
+  ⟨min (ε / 2) 1, lt_min (div_pos ε0 (by norm_num)) (by norm_num),
+    λ x h, have h : abs x < min (ε / 2) 1, by simpa [dist_eq] using h,
+      calc abs (exp x - 1) ≤ 2 * abs x : abs_exp_sub_one_le
+          (le_trans (le_of_lt h) (min_le_right _ _))
+        ... = abs x + abs x : two_mul (abs x)
+        ... < ε / 2 + ε / 2 : add_lt_add
+          (lt_of_lt_of_le h (min_le_left _ _)) (lt_of_lt_of_le h (min_le_left _ _))
+        ... = ε : by rw add_halves⟩
+
+lemma continuous_exp : continuous exp :=
+continuous_iff_tendsto.2 (λ x,
+  have H1 : tendsto (λ h, exp (x + h)) (nhds 0) (nhds (exp x)),
+    by simpa [exp_add] using tendsto_mul tendsto_const_nhds tendsto_exp_zero_one,
+  have H2 : tendsto (λ y, y - x) (nhds x) (nhds (x - x)) :=
+     tendsto_sub tendsto_id (@tendsto_const_nhds _ _ _ x _),
+  suffices tendsto ((λ h, exp (x + h)) ∘
+      (λ y, id y - (λ z, x) y)) (nhds x) (nhds (exp x)),
+    by simp only [function.comp, add_sub_cancel'_right, id.def] at this;
+      exact this,
+  tendsto.comp (by rw [sub_self] at H2; exact H2) H1)
+
+lemma continuous_sin : continuous sin :=
+continuous_mul
+  (continuous_mul
+    (continuous_sub
+      ((continuous_mul continuous_neg' continuous_const).comp continuous_exp)
+      ((continuous_mul continuous_id continuous_const).comp continuous_exp))
+    continuous_const)
+  continuous_const
+
+lemma continuous_cos : continuous cos :=
+continuous_mul
+  (continuous_add
+    ((continuous_mul continuous_id continuous_const).comp continuous_exp)
+    ((continuous_mul continuous_neg' continuous_const).comp continuous_exp))
+  continuous_const
+
+lemma continuous_tan : continuous (λ x : {x // cos x ≠ 0}, tan x) :=
+continuous_mul
+  (continuous_subtype_val.comp continuous_sin)
+  (continuous_inv subtype.property
+    (continuous_subtype_val.comp continuous_cos))
+
+lemma continuous_sinh : continuous sinh :=
+continuous_mul
+  (continuous_sub
+    continuous_exp
+    (continuous_neg'.comp continuous_exp))
+  continuous_const
+
+lemma continuous_cosh : continuous cosh :=
+continuous_mul
+  (continuous_add
+    continuous_exp
+    (continuous_neg'.comp continuous_exp))
+  continuous_const
+
+end complex
+
+namespace real
+
+lemma continuous_exp : continuous exp :=
+(complex.continuous_of_real.comp complex.continuous_exp).comp
+  complex.continuous_re
+
+lemma continuous_sin : continuous sin :=
+(complex.continuous_of_real.comp complex.continuous_sin).comp
+  complex.continuous_re
+
+lemma continuous_cos : continuous cos :=
+(complex.continuous_of_real.comp complex.continuous_cos).comp
+  complex.continuous_re
+
+lemma continuous_tan : continuous (λ x : {x // cos x ≠ 0}, tan x) :=
+by simp only [tan_eq_sin_div_cos]; exact
+continuous_mul
+  (continuous_subtype_val.comp continuous_sin)
+  (continuous_inv subtype.property
+    (continuous_subtype_val.comp continuous_cos))
+
+lemma continuous_sinh : continuous sinh :=
+(complex.continuous_of_real.comp complex.continuous_sinh).comp
+  complex.continuous_re
+
+lemma continuous_cosh : continuous cosh :=
+(complex.continuous_of_real.comp complex.continuous_cosh).comp
+  complex.continuous_re
+
+private lemma exists_exp_eq_of_one_le {x : ℝ} (hx : 1 ≤ x) : ∃ y, exp y = x :=
+let ⟨y, hy⟩ := @intermediate_value real.exp 0 (x - 1) x
+  (λ _ _ _, continuous_iff_tendsto.1 continuous_exp _) (by simpa)
+  (by simpa using add_one_le_exp_of_nonneg (sub_nonneg.2 hx)) (sub_nonneg.2 hx) in
+⟨y, hy.2.2⟩
+
+lemma exists_exp_eq_of_pos {x : ℝ} (hx : 0 < x) : ∃ y, exp y = x :=
+match le_total x 1 with
+| (or.inl hx1) := let ⟨y, hy⟩ := exists_exp_eq_of_one_le (one_le_inv hx hx1) in
+  ⟨-y, by rw [exp_neg, hy, inv_inv']⟩
+| (or.inr hx1) := exists_exp_eq_of_one_le hx1
+end
+
+noncomputable def log (x : ℝ) : ℝ :=
+if hx : 0 < x then classical.some (exists_exp_eq_of_pos hx) else 0
+
+lemma exp_log {x : ℝ} (hx : 0 < x) : exp (log x) = x :=
+by rw [log, dif_pos hx]; exact classical.some_spec (exists_exp_eq_of_pos hx)
+
+@[simp] lemma log_exp (x : ℝ) : log (exp x) = x :=
+exp_injective $ exp_log (exp_pos x)
+
+@[simp] lemma log_zero : log 0 = 0 :=
+by simp [log, lt_irrefl]
+
+@[simp] lemma log_one : log 1 = 0 :=
+exp_injective $ by rw [exp_log zero_lt_one, exp_zero]
+
+lemma exists_cos_eq_zero : ∃ x, 1 ≤ x ∧ x ≤ 2 ∧ cos x = 0 :=
+real.intermediate_value'
+  (λ x _ _, continuous_iff_tendsto.1 continuous_cos _)
+  (le_of_lt cos_one_pos)
+  (le_of_lt cos_two_neg) (by norm_num)
+
+noncomputable def pi : ℝ := 2 * classical.some exists_cos_eq_zero
+
+local notation `π` := pi
+
+@[simp] lemma cos_pi_div_two : cos (π / 2) = 0 :=
+by rw [pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
+  exact (classical.some_spec exists_cos_eq_zero).2.2
+
+lemma one_le_pi_div_two : (1 : ℝ) ≤ π / 2 :=
+by rw [pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
+  exact (classical.some_spec exists_cos_eq_zero).1
+
+lemma pi_div_two_le_two : π / 2 ≤ 2 :=
+by rw [pi, mul_div_cancel_left _ (@two_ne_zero' ℝ _ _ _)];
+  exact (classical.some_spec exists_cos_eq_zero).2.1
+
+lemma two_le_pi : (2 : ℝ) ≤ π :=
+(div_le_div_right (show (0 : ℝ) < 2, by norm_num)).1
+  (by rw div_self (@two_ne_zero' ℝ _ _ _); exact one_le_pi_div_two)
+
+lemma pi_le_four : π ≤ 4 :=
+(div_le_div_right (show (0 : ℝ) < 2, by norm_num)).1
+  (calc π / 2 ≤ 2 : pi_div_two_le_two
+    ... = 4 / 2 : by norm_num)
+
+lemma pi_pos : 0 < π :=
+lt_of_lt_of_le (by norm_num) two_le_pi
+
+lemma pi_div_two_pos : 0 < π / 2 :=
+half_pos pi_pos
+
+lemma two_pi_pos : 0 < 2 * π :=
+by linarith using [pi_pos]
+
+@[simp] lemma sin_pi : sin π = 0 :=
+by rw [← mul_div_cancel_left pi (@two_ne_zero ℝ _), two_mul, add_div,
+    sin_add, cos_pi_div_two]; simp
+
+@[simp] lemma cos_pi : cos π = -1 :=
+by rw [← mul_div_cancel_left pi (@two_ne_zero ℝ _), mul_div_assoc,
+    cos_two_mul, cos_pi_div_two];
+  simp [bit0, pow_add]
+
+@[simp] lemma sin_two_pi : sin (2 * π) = 0 :=
+by simp [two_mul, sin_add]
+
+@[simp] lemma cos_two_pi : cos (2 * π) = 1 :=
+by simp [two_mul, cos_add]
+
+lemma sin_add_pi (x : ℝ) : sin (x + π) = -sin x :=
+by simp [sin_add]
+
+lemma sin_add_two_pi (x : ℝ) : sin (x + 2 * π) = sin x :=
+by simp [sin_add_pi, sin_add, sin_two_pi, cos_two_pi]
+
+lemma cos_add_two_pi (x : ℝ) : cos (x + 2 * π) = cos x :=
+by simp [cos_add, cos_two_pi, sin_two_pi]
+
+lemma sin_pi_sub (x : ℝ) : sin (π - x) = sin x :=
+by simp [sin_add]
+
+lemma cos_add_pi (x : ℝ) : cos (x + π) = -cos x :=
+by simp [cos_add]
+
+lemma cos_pi_sub (x : ℝ) : cos (π - x) = -cos x :=
+by simp [cos_add]
+
+lemma sin_pos_of_pos_of_lt_pi {x : ℝ} (h0x : 0 < x) (hxp : x < π) : 0 < sin x :=
+if hx2 : x ≤ 2 then sin_pos_of_pos_of_le_two h0x hx2
+else
+  have (2 : ℝ) + 2 = 4, from rfl,
+  have π - x ≤ 2, from sub_le_iff_le_add.2
+    (le_trans pi_le_four (this ▸ add_le_add_left (le_of_not_ge hx2) _)),
+  sin_pi_sub x ▸ sin_pos_of_pos_of_le_two (sub_pos.2 hxp) this
+
+lemma sin_nonneg_of_nonneg_of_le_pi {x : ℝ} (h0x : 0 ≤ x) (hxp : x ≤ π) : 0 ≤ sin x :=
+match lt_or_eq_of_le h0x with
+| or.inl h0x := (lt_or_eq_of_le hxp).elim
+  (le_of_lt ∘ sin_pos_of_pos_of_lt_pi h0x)
+  (λ hpx, by simp [hpx])
+| or.inr h0x := by simp [h0x.symm]
+end
+
+lemma sin_neg_of_neg_of_neg_pi_lt {x : ℝ} (hx0 : x < 0) (hpx : -π < x) : sin x < 0 :=
+neg_pos.1 $ sin_neg x ▸ sin_pos_of_pos_of_lt_pi (neg_pos.2 hx0) (neg_lt.1 hpx)
+
+lemma sin_nonpos_of_nonnpos_of_neg_pi_le {x : ℝ} (hx0 : x ≤ 0) (hpx : -π ≤ x) : sin x ≤ 0 :=
+neg_nonneg.1 $ sin_neg x ▸ sin_nonneg_of_nonneg_of_le_pi (neg_nonneg.2 hx0) (neg_le.1 hpx)
+
+@[simp] lemma sin_pi_div_two : sin (π / 2) = 1 :=
+have sin (π / 2) = 1 ∨ sin (π / 2) = -1 :=
+by simpa [pow_two, mul_self_eq_one_iff] using sin_pow_two_add_cos_pow_two (π / 2),
+this.resolve_right
+  (λ h, (show ¬(0 : ℝ) < -1, by norm_num) $
+    h ▸ sin_pos_of_pos_of_lt_pi pi_div_two_pos (half_lt_self pi_pos))
+
+lemma sin_add_pi_div_two (x : ℝ) : sin (x + π / 2) = cos x :=
+by simp [sin_add]
+
+lemma sin_sub_pi_div_two (x : ℝ) : sin (x - π / 2) = -cos x :=
+by simp [sin_add]
+
+lemma sin_pi_div_two_sub (x : ℝ) : sin (π / 2 - x) = cos x :=
+by simp [sin_add]
+
+lemma cos_add_pi_div_two (x : ℝ) : cos (x + π / 2) = -sin x :=
+by simp [cos_add]
+
+lemma cos_sub_pi_div_two (x : ℝ) : cos (x - π / 2) = sin x :=
+by simp [cos_add]
+
+lemma cos_pi_div_two_sub (x : ℝ) : cos (π / 2 - x) = sin x :=
+by rw [← cos_neg, neg_sub, cos_sub_pi_div_two]
+
+lemma cos_pos_of_neg_pi_div_two_lt_of_lt_pi_div_two
+  {x : ℝ} (hx₁ : -(π / 2) < x) (hx₂ : x < π / 2) : 0 < cos x :=
+sin_add_pi_div_two x ▸ sin_pos_of_pos_of_lt_pi (by linarith) (by linarith)
+
+lemma cos_nonneg_of_neg_pi_div_two_le_of_le_pi_div_two
+  {x : ℝ} (hx₁ : -(π / 2) ≤ x) (hx₂ : x ≤ π / 2) : 0 ≤ cos x :=
+match lt_or_eq_of_le hx₁, lt_or_eq_of_le hx₂ with
+| or.inl hx₁, or.inl hx₂ := le_of_lt (cos_pos_of_neg_pi_div_two_lt_of_lt_pi_div_two hx₁ hx₂)
+| or.inl hx₁, or.inr hx₂ := by simp [hx₂]
+| or.inr hx₁, _          := by simp [hx₁.symm]
+end
+
+lemma cos_neg_of_pi_div_two_lt_of_lt {x : ℝ} (hx₁ : π / 2 < x) (hx₂ : x < π + π / 2) : cos x < 0 :=
+neg_pos.1 $ cos_pi_sub x ▸
+  cos_pos_of_neg_pi_div_two_lt_of_lt_pi_div_two (by linarith) (by linarith)
+
+lemma cos_nonpos_of_pi_div_two_le_of_le {x : ℝ} (hx₁ : π / 2 ≤ x) (hx₂ : x ≤ π + π / 2) : cos x ≤ 0 :=
+neg_nonneg.1 $ cos_pi_sub x ▸
+  cos_nonneg_of_neg_pi_div_two_le_of_le_pi_div_two (by linarith) (by linarith)
+
+lemma sin_nat_mul_pi (n : ℕ) : sin (n * π) = 0 :=
+by induction n; simp [add_mul, sin_add, *]
+
+lemma sin_int_mul_pi (n : ℤ) : sin (n * π) = 0 :=
+by cases n; simp [add_mul, sin_add, *, sin_nat_mul_pi]
+
+lemma cos_nat_mul_two_pi (n : ℕ) : cos (n * (2 * π)) = 1 :=
+by induction n; simp [*, mul_add, cos_add, add_mul, cos_two_pi, sin_two_pi]
+
+lemma cos_int_mul_two_pi (n : ℤ) : cos (n * (2 * π)) = 1 :=
+by cases n; simp only [cos_nat_mul_two_pi, int.of_nat_eq_coe,
+  int.neg_succ_of_nat_coe, int.cast_coe_nat, int.cast_neg,
+  (neg_mul_eq_neg_mul _ _).symm, cos_neg]
+
+lemma cos_int_mul_two_pi_add_pi (n : ℤ) : cos (n * (2 * π) + π) = -1 :=
+by simp [cos_add, sin_add, cos_int_mul_two_pi]
+
+lemma sin_eq_zero_iff_of_lt_of_lt {x : ℝ} (hx₁ : -π < x) (hx₂ : x < π) :
+  sin x = 0 ↔ x = 0 :=
+⟨λ h, le_antisymm
+    (le_of_not_gt (λ h0, lt_irrefl (0 : ℝ) $
+      calc 0 < sin x : sin_pos_of_pos_of_lt_pi h0 hx₂
+        ... = 0 : h))
+    (le_of_not_gt (λ h0, lt_irrefl (0 : ℝ) $
+      calc 0 = sin x : h.symm
+        ... < 0 : sin_neg_of_neg_of_neg_pi_lt h0 hx₁)),
+  λ h, by simp [h]⟩
+
+lemma sin_eq_zero_iff {x : ℝ} : sin x = 0 ↔ ∃ n : ℤ, (n : ℝ) * π = x :=
+⟨λ h, ⟨⌊x / π⌋, le_antisymm (sub_nonneg.1 (sub_floor_div_mul_nonneg _ pi_pos))
+  (sub_nonpos.1 $ le_of_not_gt $ λ h₃, ne_of_lt (sin_pos_of_pos_of_lt_pi h₃ (sub_floor_div_mul_lt _ pi_pos))
+    (by simp [sin_add, h, sin_int_mul_pi]))⟩,
+  λ ⟨n, hn⟩, hn ▸ sin_int_mul_pi _⟩
+
+lemma sin_eq_zero_iff_cos_eq {x : ℝ} : sin x = 0 ↔ cos x = 1 ∨ cos x = -1 :=
+by rw [← mul_self_eq_one_iff (cos x), ← sin_pow_two_add_cos_pow_two x,
+    pow_two, pow_two, ← sub_eq_iff_eq_add, sub_self];
+  exact ⟨λ h, by rw [h, mul_zero], eq_zero_of_mul_self_eq_zero ∘ eq.symm⟩
+
+lemma cos_eq_one_iff (x : ℝ) : cos x = 1 ↔ ∃ n : ℤ, (n : ℝ) * (2 * π) = x :=
+⟨λ h, let ⟨n, hn⟩ := sin_eq_zero_iff.1 (sin_eq_zero_iff_cos_eq.2 (or.inl h)) in
+    ⟨n / 2, (int.mod_two_eq_zero_or_one n).elim
+      (λ hn0, by rwa [← mul_assoc, ← @int.cast_two ℝ, ← int.cast_mul, int.div_mul_cancel
+        ((int.dvd_iff_mod_eq_zero _ _).2 hn0)])
+      (λ hn1, by rw [← int.mod_add_div n 2, hn1, int.cast_add, int.cast_one, add_mul,
+          one_mul, add_comm, mul_comm (2 : ℤ), int.cast_mul, mul_assoc, int.cast_two] at hn;
+        rw [← hn, cos_int_mul_two_pi_add_pi] at h;
+        exact absurd h (by norm_num))⟩,
+  λ ⟨n, hn⟩, hn ▸ cos_int_mul_two_pi _⟩
+
+lemma cos_eq_one_iff_of_lt_of_lt {x : ℝ} (hx₁ : -(2 * π) < x) (hx₂ : x < 2 * π) : cos x = 1 ↔ x = 0 :=
+⟨λ h, let ⟨n, hn⟩ := (cos_eq_one_iff x).1 h in
+    begin
+      clear _let_match,
+      subst hn,
+      rw [mul_lt_iff_lt_one_left two_pi_pos, ← int.cast_one, int.cast_lt, ← int.le_sub_one_iff, sub_self] at hx₂,
+      rw [neg_lt, neg_mul_eq_neg_mul, mul_lt_iff_lt_one_left two_pi_pos, neg_lt,
+        ← int.cast_one, ← int.cast_neg, int.cast_lt, ← int.add_one_le_iff, neg_add_self] at hx₁,
+      exact mul_eq_zero.2 (or.inl (int.cast_eq_zero.2 (le_antisymm hx₂ hx₁))),
+    end,
+  λ h, by simp [h]⟩
+
+lemma cos_lt_cos_of_nonneg_of_le_pi_div_two {x y : ℝ} (hx₁ : 0 ≤ x) (hx₂ : x ≤ π / 2)
+  (hy₁ : 0 ≤ y) (hy₂ : y ≤ π / 2) (hxy : x < y) : cos y < cos x :=
+calc cos y = cos x * cos (y - x) - sin x * sin (y - x) :
+  by rw [← cos_add, add_sub_cancel'_right]
+... < (cos x * 1) - sin x * sin (y - x) :
+  sub_lt_sub_right ((mul_lt_mul_left
+    (cos_pos_of_neg_pi_div_two_lt_of_lt_pi_div_two (lt_of_lt_of_le (neg_neg_of_pos pi_div_two_pos) hx₁)
+      (lt_of_lt_of_le hxy hy₂))).2
+        (lt_of_le_of_ne (cos_le_one _) (mt (cos_eq_one_iff_of_lt_of_lt
+          (show -(2 * π) < y - x, by linarith) (show y - x < 2 * π, by linarith)).1
+            (sub_ne_zero.2 (ne_of_lt hxy).symm)))) _
+... ≤ _ : by rw mul_one;
+  exact sub_le_self _ (mul_nonneg (sin_nonneg_of_nonneg_of_le_pi hx₁ (by linarith))
+    (sin_nonneg_of_nonneg_of_le_pi (by linarith) (by linarith)))
+
+lemma cos_lt_cos_of_nonneg_of_le_pi {x y : ℝ} (hx₁ : 0 ≤ x) (hx₂ : x ≤ π)
+  (hy₁ : 0 ≤ y) (hy₂ : y ≤ π) (hxy : x < y) : cos y < cos x :=
+match (le_total x (π / 2) : x ≤ π / 2 ∨ π / 2 ≤ x), le_total y (π / 2) with
+| or.inl hx, or.inl hy := cos_lt_cos_of_nonneg_of_le_pi_div_two hx₁ hx hy₁ hy hxy
+| or.inl hx, or.inr hy := (lt_or_eq_of_le hx).elim
+  (λ hx, calc cos y ≤ 0 : cos_nonpos_of_pi_div_two_le_of_le hy (by linarith using [pi_pos])
+    ... < cos x : cos_pos_of_neg_pi_div_two_lt_of_lt_pi_div_two (by linarith) hx)
+  (λ hx, calc cos y < 0 : cos_neg_of_pi_div_two_lt_of_lt (by linarith) (by linarith using [pi_pos])
+    ... = cos x : by rw [hx, cos_pi_div_two])
+| or.inr hx, or.inl hy := by linarith
+| or.inr hx, or.inr hy := neg_lt_neg_iff.1 (by rw [← cos_pi_sub, ← cos_pi_sub];
+  apply cos_lt_cos_of_nonneg_of_le_pi_div_two; linarith)
+end
+
+lemma cos_le_cos_of_nonneg_of_le_pi {x y : ℝ} (hx₁ : 0 ≤ x) (hx₂ : x ≤ π)
+  (hy₁ : 0 ≤ y) (hy₂ : y ≤ π) (hxy : x ≤ y) : cos y ≤ cos x :=
+(lt_or_eq_of_le hxy).elim
+  (le_of_lt ∘ cos_lt_cos_of_nonneg_of_le_pi hx₁ hx₂ hy₁ hy₂)
+  (λ h, h ▸ le_refl _)
+
+lemma sin_lt_sin_of_le_of_le_pi_div_two {x y : ℝ} (hx₁ : -(π / 2) ≤ x) (hx₂ : x ≤ π / 2) (hy₁ : -(π / 2) ≤ y)
+  (hy₂ : y ≤ π / 2) (hxy : x < y) : sin x < sin y :=
+by rw [← cos_sub_pi_div_two, ← cos_sub_pi_div_two, ← cos_neg (x - _), ← cos_neg (y - _)];
+  apply cos_lt_cos_of_nonneg_of_le_pi; linarith
+
+lemma sin_le_sin_of_le_of_le_pi_div_two {x y : ℝ} (hx₁ : -(π / 2) ≤ x) (hx₂ : x ≤ π / 2) (hy₁ : -(π / 2) ≤ y)
+  (hy₂ : y ≤ π / 2) (hxy : x ≤ y) : sin x ≤ sin y :=
+(lt_or_eq_of_le hxy).elim
+  (le_of_lt ∘ sin_lt_sin_of_le_of_le_pi_div_two hx₁ hx₂ hy₁ hy₂)
+  (λ h, h ▸ le_refl _)
+
+lemma sin_inj_of_le_of_le_pi_div_two {x y : ℝ} (hx₁ : -(π / 2) ≤ x) (hx₂ : x ≤ π / 2) (hy₁ : -(π / 2) ≤ y)
+  (hy₂ : y ≤ π / 2) (hxy : sin x = sin y) : x = y :=
+match lt_trichotomy x y with
+| or.inl h          := absurd (sin_lt_sin_of_le_of_le_pi_div_two hx₁ hx₂ hy₁ hy₂ h) (by rw hxy; exact lt_irrefl _)
+| or.inr (or.inl h) := h
+| or.inr (or.inr h) := absurd (sin_lt_sin_of_le_of_le_pi_div_two hy₁ hy₂ hx₁ hx₂ h) (by rw hxy; exact lt_irrefl _)
+end
+
+lemma cos_inj_of_nonneg_of_le_pi {x y : ℝ} (hx₁ : 0 ≤ x) (hx₂ : x ≤ π) (hy₁ : 0 ≤ y) (hy₂ : y ≤ π)
+  (hxy : cos x = cos y) : x = y :=
+begin
+  rw [← sin_pi_div_two_sub, ← sin_pi_div_two_sub] at hxy,
+  refine (sub_left_inj).1 (sin_inj_of_le_of_le_pi_div_two _ _ _ _ hxy);
+  linarith
+end
+
+lemma exists_sin_eq {x : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) : ∃ y, -(π / 2) ≤ y ∧ y ≤ π / 2 ∧ sin y = x :=
+@real.intermediate_value sin (-(π / 2)) (π / 2) x
+  (λ _ _ _, continuous_iff_tendsto.1 continuous_sin _)
+  (by rwa [sin_neg, sin_pi_div_two]) (by rwa sin_pi_div_two)
+  (le_trans (neg_nonpos.2 (le_of_lt pi_div_two_pos)) (le_of_lt pi_div_two_pos))
+
+/-- Inverse of the `sin` function, returns values in the range `-π / 2 ≤ arcsin x` and `arcsin x ≤ π / 2`.
+  If the argument is not between `-1` and `1` it defaults to `0` -/
+noncomputable def arcsin (x : ℝ) : ℝ :=
+if hx : -1 ≤ x ∧ x ≤ 1 then classical.some (exists_sin_eq hx.1 hx.2) else 0
+
+lemma arcsin_le_pi_div_two (x : ℝ) : arcsin x ≤ π / 2 :=
+if hx : -1 ≤ x ∧ x ≤ 1
+then by rw [arcsin, dif_pos hx]; exact (classical.some_spec (exists_sin_eq hx.1 hx.2)).2.1
+else by rw [arcsin, dif_neg hx]; exact le_of_lt pi_div_two_pos
+
+lemma neg_pi_div_two_le_arcsin (x : ℝ) : -(π / 2) ≤ arcsin x :=
+if hx : -1 ≤ x ∧ x ≤ 1
+then by rw [arcsin, dif_pos hx]; exact (classical.some_spec (exists_sin_eq hx.1 hx.2)).1
+else by rw [arcsin, dif_neg hx]; exact neg_nonpos.2 (le_of_lt pi_div_two_pos)
+
+lemma sin_arcsin {x : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) : sin (arcsin x) = x :=
+by rw [arcsin, dif_pos (and.intro hx₁ hx₂)];
+  exact (classical.some_spec (exists_sin_eq hx₁ hx₂)).2.2
+
+lemma arcsin_sin {x : ℝ} (hx₁ : -(π / 2) ≤ x) (hx₂ : x ≤ π / 2) : arcsin (sin x) = x :=
+sin_inj_of_le_of_le_pi_div_two (neg_pi_div_two_le_arcsin _) (arcsin_le_pi_div_two _) hx₁ hx₂
+  (by rw sin_arcsin (neg_one_le_sin _) (sin_le_one _))
+
+lemma arcsin_inj {x y : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) (hy₁ : -1 ≤ y) (hy₂ : y ≤ 1)
+  (hxy : arcsin x = arcsin y) : x = y :=
+by rw [← sin_arcsin hx₁ hx₂, ← sin_arcsin hy₁ hy₂, hxy]
+
+@[simp] lemma arcsin_zero : arcsin 0 = 0 :=
+sin_inj_of_le_of_le_pi_div_two
+  (neg_pi_div_two_le_arcsin _)
+  (arcsin_le_pi_div_two _)
+  (neg_nonpos.2 (le_of_lt pi_div_two_pos))
+  (le_of_lt pi_div_two_pos)
+  (by rw [sin_arcsin, sin_zero]; norm_num)
+
+@[simp] lemma arcsin_one : arcsin 1 = π / 2 :=
+sin_inj_of_le_of_le_pi_div_two
+  (neg_pi_div_two_le_arcsin _)
+  (arcsin_le_pi_div_two _)
+  (by linarith using [pi_pos])
+  (le_refl _)
+  (by rw [sin_arcsin, sin_pi_div_two]; norm_num)
+
+@[simp] lemma arcsin_neg (x : ℝ) : arcsin (-x) = -arcsin x :=
+if h : -1 ≤ x ∧ x ≤ 1 then
+  have -1 ≤ -x ∧ -x ≤ 1, by rwa [neg_le_neg_iff, neg_le, and.comm],
+  sin_inj_of_le_of_le_pi_div_two
+    (neg_pi_div_two_le_arcsin _)
+    (arcsin_le_pi_div_two _)
+    (neg_le_neg (arcsin_le_pi_div_two _))
+    (neg_le.1 (neg_pi_div_two_le_arcsin _))
+    (by rw [sin_arcsin this.1 this.2, sin_neg, sin_arcsin h.1 h.2])
+else
+  have ¬(-1 ≤ -x ∧ -x ≤ 1) := by rwa [neg_le_neg_iff, neg_le, and.comm],
+  by rw [arcsin, arcsin, dif_neg h, dif_neg this, neg_zero]
+
+@[simp] lemma arcsin_neg_one : arcsin (-1) = -(π / 2) := by simp
+
+lemma arcsin_nonneg {x : ℝ} (hx : 0 ≤ x) : 0 ≤ arcsin x :=
+if hx₁ : x ≤ 1 then
+not_lt.1 (λ h, not_lt.2 hx begin
+  have := sin_lt_sin_of_le_of_le_pi_div_two
+    (neg_pi_div_two_le_arcsin _) (arcsin_le_pi_div_two _)
+    (neg_nonpos.2 (le_of_lt pi_div_two_pos)) (le_of_lt pi_div_two_pos) h,
+  rw [real.sin_arcsin, sin_zero] at this; linarith
+end)
+else by rw [arcsin, dif_neg]; simp [hx₁]
+
+lemma arcsin_eq_zero_iff {x : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) : arcsin x = 0 ↔ x = 0 :=
+⟨λ h, have sin (arcsin x) = 0, by simp [h],
+  by rwa [sin_arcsin hx₁ hx₂] at this,
+λ h, by simp [h]⟩
+
+lemma arcsin_pos {x : ℝ} (hx₁ : 0 < x) (hx₂ : x ≤ 1) : 0 < arcsin x :=
+lt_of_le_of_ne (arcsin_nonneg (le_of_lt hx₁))
+  (ne.symm (mt (arcsin_eq_zero_iff (by linarith) hx₂).1 (ne_of_lt hx₁).symm))
+
+lemma arcsin_nonpos {x : ℝ} (hx : x ≤ 0) : arcsin x ≤ 0 :=
+neg_nonneg.1 (arcsin_neg x ▸ arcsin_nonneg (neg_nonneg.2 hx))
+
+/-- Inverse of the `cos` function, returns values in the range `0 ≤ arccos x` and `arccos x ≤ π`.
+  If the argument is not between `-1` and `1` it defaults to `π / 2` -/
+noncomputable def arccos (x : ℝ) : ℝ :=
+π / 2 - arcsin x
+
+lemma arccos_eq_pi_div_two_sub_arcsin (x : ℝ) : arccos x = π / 2 - arcsin x := rfl
+
+lemma arcsin_eq_pi_div_two_sub_arccos (x : ℝ) : arcsin x = π / 2 - arccos x := by simp [arccos]
+
+lemma arccos_le_pi (x : ℝ) : arccos x ≤ π :=
+by unfold arccos; linarith using [neg_pi_div_two_le_arcsin x]
+
+lemma arccos_nonneg (x : ℝ) : 0 ≤ arccos x :=
+by unfold arccos; linarith using [arcsin_le_pi_div_two x]
+
+lemma cos_arccos {x : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) : cos (arccos x) = x :=
+by rw [arccos, cos_pi_div_two_sub, sin_arcsin hx₁ hx₂]
+
+lemma arccos_cos {x : ℝ} (hx₁ : 0 ≤ x) (hx₂ : x ≤ π) : arccos (cos x) = x :=
+by rw [arccos, ← sin_pi_div_two_sub, arcsin_sin]; simp; linarith
+
+lemma arccos_inj {x y : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) (hy₁ : -1 ≤ y) (hy₂ : y ≤ 1)
+  (hxy : arccos x = arccos y) : x = y :=
+arcsin_inj hx₁ hx₂ hy₁ hy₂ $ by simp [arccos, *] at *
+
+@[simp] lemma arccos_zero : arccos 0 = π / 2 := by simp [arccos]
+
+@[simp] lemma arccos_one : arccos 1 = 0 := by simp [arccos]
+
+@[simp] lemma arccos_neg_one : arccos (-1) = π := by simp [arccos, add_halves]
+
+lemma arccos_neg (x : ℝ) : arccos (-x) = π - arccos x :=
+by rw [← add_halves π, arccos, arcsin_neg, arccos, add_sub_assoc, sub_sub_self]; simp
+
+lemma cos_arcsin_nonneg (x : ℝ) : 0 ≤ cos (arcsin x) :=
+cos_nonneg_of_neg_pi_div_two_le_of_le_pi_div_two
+    (neg_pi_div_two_le_arcsin _) (arcsin_le_pi_div_two _)
+
+lemma cos_arcsin {x : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) : cos (arcsin x) = sqrt (1 - x ^ 2) :=
+have sin (arcsin x) ^ 2 + cos (arcsin x) ^ 2 = 1 := sin_pow_two_add_cos_pow_two (arcsin x),
+begin
+  rw [← eq_sub_iff_add_eq', ← sqrt_inj (pow_two_nonneg _) (sub_nonneg.2 (sin_pow_two_le_one (arcsin x))),
+    pow_two, sqrt_mul_self (cos_arcsin_nonneg _)] at this,
+  rw [this, sin_arcsin hx₁ hx₂],
+end
+
+lemma sin_arccos {x : ℝ} (hx₁ : -1 ≤ x) (hx₂ : x ≤ 1) : sin (arccos x) = sqrt (1 - x ^ 2) :=
+by rw [arccos_eq_pi_div_two_sub_arcsin, sin_pi_div_two_sub, cos_arcsin hx₁ hx₂]
+
+lemma abs_div_sqrt_one_add_lt (x : ℝ) : abs (x / sqrt (1 + x ^ 2)) < 1 :=
+have h₁ : 0 < 1 + x ^ 2, from add_pos_of_pos_of_nonneg zero_lt_one (pow_two_nonneg _),
+have h₂ : 0 < sqrt (1 + x ^ 2), from sqrt_pos.2 h₁,
+by rw [abs_div, div_lt_iff (abs_pos_of_pos h₂), one_mul,
+    mul_self_lt_mul_self_iff (abs_nonneg x) (abs_nonneg _),
+    ← abs_mul, ← abs_mul, mul_self_sqrt (add_nonneg zero_le_one (pow_two_nonneg _)),
+    abs_of_nonneg (mul_self_nonneg x), abs_of_nonneg (le_of_lt h₁), pow_two, add_comm];
+  exact lt_add_one _
+
+lemma div_sqrt_one_add_lt_one (x : ℝ) : x / sqrt (1 + x ^ 2) < 1 :=
+(abs_lt.1 (abs_div_sqrt_one_add_lt _)).2
+
+lemma neg_one_lt_div_sqrt_one_add (x : ℝ) : -1 < x / sqrt (1 + x ^ 2) :=
+(abs_lt.1 (abs_div_sqrt_one_add_lt _)).1
+
+lemma tan_pos_of_pos_of_lt_pi_div_two {x : ℝ} (h0x : 0 < x) (hxp : x < π / 2) : 0 < tan x :=
+by rw tan_eq_sin_div_cos; exact div_pos (sin_pos_of_pos_of_lt_pi h0x (by linarith))
+  (cos_pos_of_neg_pi_div_two_lt_of_lt_pi_div_two (by linarith) hxp)
+
+lemma tan_nonneg_of_nonneg_of_le_pi_div_two {x : ℝ} (h0x : 0 ≤ x) (hxp : x ≤ π / 2) : 0 ≤ tan x :=
+match lt_or_eq_of_le h0x, lt_or_eq_of_le hxp with
+| or.inl hx0, or.inl hxp := le_of_lt (tan_pos_of_pos_of_lt_pi_div_two hx0 hxp)
+| or.inl hx0, or.inr hxp := by simp [hxp, tan_eq_sin_div_cos]
+| or.inr hx0, _          := by simp [hx0.symm]
+end
+
+lemma tan_neg_of_neg_of_pi_div_two_lt {x : ℝ} (hx0 : x < 0) (hpx : -(π / 2) < x) : tan x < 0 :=
+neg_pos.1 (tan_neg x ▸ tan_pos_of_pos_of_lt_pi_div_two (by linarith) (by linarith using [pi_pos]))
+
+lemma tan_nonpos_of_nonpos_of_neg_pi_div_two_le {x : ℝ} (hx0 : x ≤ 0) (hpx : -(π / 2) ≤ x) : tan x ≤ 0 :=
+neg_nonneg.1 (tan_neg x ▸ tan_nonneg_of_nonneg_of_le_pi_div_two (by linarith) (by linarith using [pi_pos]))
+
+lemma tan_lt_tan_of_nonneg_of_lt_pi_div_two {x y : ℝ} (hx₁ : 0 ≤ x) (hx₂ : x < π / 2) (hy₁ : 0 ≤ y)
+  (hy₂ : y < π / 2) (hxy : x < y) : tan x < tan y :=
+begin
+  rw [tan_eq_sin_div_cos, tan_eq_sin_div_cos],
+  exact div_lt_div
+    (sin_lt_sin_of_le_of_le_pi_div_two (by linarith) (le_of_lt hx₂)
+      (by linarith) (le_of_lt hy₂) hxy)
+    (cos_le_cos_of_nonneg_of_le_pi hx₁ (by linarith) hy₁ (by linarith) (le_of_lt hxy))
+    (sin_nonneg_of_nonneg_of_le_pi hy₁ (by linarith))
+    (cos_pos_of_neg_pi_div_two_lt_of_lt_pi_div_two (by linarith) hy₂)
+end
+
+lemma tan_lt_tan_of_lt_of_lt_pi_div_two {x y : ℝ} (hx₁ : -(π / 2) < x) (hx₂ : x < π / 2)
+  (hy₁ : -(π / 2) < y) (hy₂ : y < π / 2) (hxy : x < y) : tan x < tan y :=
+match le_total x 0, le_total y 0 with
+| or.inl hx0, or.inl hy0 := neg_lt_neg_iff.1 $ by rw [← tan_neg, ← tan_neg]; exact
+  tan_lt_tan_of_nonneg_of_lt_pi_div_two (neg_nonneg.2 hy0) (neg_lt.2 hy₁)
+    (neg_nonneg.2 hx0) (neg_lt.2 hx₁) (neg_lt_neg hxy)
+| or.inl hx0, or.inr hy0 := (lt_or_eq_of_le hy0).elim
+  (λ hy0, calc tan x ≤ 0 : tan_nonpos_of_nonpos_of_neg_pi_div_two_le hx0 (le_of_lt hx₁)
+    ... < tan y : tan_pos_of_pos_of_lt_pi_div_two hy0 hy₂)
+  (λ hy0, by rw [← hy0, tan_zero]; exact
+    tan_neg_of_neg_of_pi_div_two_lt (hy0.symm ▸ hxy) hx₁)
+| or.inr hx0, or.inl hy0 := by linarith
+| or.inr hx0, or.inr hy0 := tan_lt_tan_of_nonneg_of_lt_pi_div_two hx0 hx₂ hy0 hy₂ hxy
+end
+
+lemma tan_inj_of_lt_of_lt_pi_div_two {x y : ℝ} (hx₁ : -(π / 2) < x) (hx₂ : x < π / 2)
+  (hy₁ : -(π / 2) < y) (hy₂ : y < π / 2) (hxy : tan x = tan y) : x = y :=
+match lt_trichotomy x y with
+| or.inl h          := absurd (tan_lt_tan_of_lt_of_lt_pi_div_two hx₁ hx₂ hy₁ hy₂ h) (by rw hxy; exact lt_irrefl _)
+| or.inr (or.inl h) := h
+| or.inr (or.inr h) := absurd (tan_lt_tan_of_lt_of_lt_pi_div_two hy₁ hy₂ hx₁ hx₂ h) (by rw hxy; exact lt_irrefl _)
+end
+
+/-- Inverse of the `tan` function, returns values in the range `-π / 2 < arctan x` and `arctan x < π / 2` -/
+noncomputable def arctan (x : ℝ) : ℝ :=
+arcsin (x / sqrt (1 + x ^ 2))
+
+lemma sin_arctan (x : ℝ) : sin (arctan x) = x / sqrt (1 + x ^ 2) :=
+sin_arcsin (le_of_lt (neg_one_lt_div_sqrt_one_add _)) (le_of_lt (div_sqrt_one_add_lt_one _))
+
+lemma cos_arctan (x : ℝ) : cos (arctan x) = 1 / sqrt (1 + x ^ 2) :=
+have h₁ : (0 : ℝ) < 1 + x ^ 2,
+  from add_pos_of_pos_of_nonneg zero_lt_one (pow_two_nonneg _),
+have h₂ : (x / sqrt (1 + x ^ 2)) ^ 2 < 1,
+  by rw [pow_two, ← abs_mul_self, _root_.abs_mul];
+    exact mul_lt_one_of_nonneg_of_lt_one_left (abs_nonneg _)
+      (abs_div_sqrt_one_add_lt _) (le_of_lt (abs_div_sqrt_one_add_lt _)),
+by rw [arctan, cos_arcsin (le_of_lt (neg_one_lt_div_sqrt_one_add _)) (le_of_lt (div_sqrt_one_add_lt_one _)),
+    one_div_eq_inv, ← sqrt_inv, sqrt_inj (sub_nonneg.2 (le_of_lt h₂)) (inv_nonneg.2 (le_of_lt h₁)),
+    div_pow _ (mt sqrt_eq_zero'.1 (not_le.2 h₁)), pow_two (sqrt _), mul_self_sqrt (le_of_lt h₁),
+    ← domain.mul_left_inj (ne.symm (ne_of_lt h₁)), mul_sub,
+    mul_div_cancel' _ (ne.symm (ne_of_lt h₁)), mul_inv_cancel (ne.symm (ne_of_lt h₁))];
+  simp
+
+lemma tan_arctan (x : ℝ) : tan (arctan x) = x :=
+by rw [tan_eq_sin_div_cos, sin_arctan, cos_arctan, div_div_div_div_eq, mul_one,
+    mul_div_assoc,
+    div_self (mt sqrt_eq_zero'.1 (not_le_of_gt (add_pos_of_pos_of_nonneg zero_lt_one (pow_two_nonneg x)))),
+    mul_one]
+
+lemma arctan_lt_pi_div_two (x : ℝ) : arctan x < π / 2 :=
+lt_of_le_of_ne (arcsin_le_pi_div_two _)
+  (λ h, ne_of_lt (div_sqrt_one_add_lt_one x) $
+    by rw [← sin_arcsin (le_of_lt (neg_one_lt_div_sqrt_one_add _))
+        (le_of_lt (div_sqrt_one_add_lt_one _)), ← arctan, h, sin_pi_div_two])
+
+lemma neg_pi_div_two_lt_arctan (x : ℝ) : -(π / 2) < arctan x :=
+lt_of_le_of_ne (neg_pi_div_two_le_arcsin _)
+  (λ h, ne_of_lt (neg_one_lt_div_sqrt_one_add x) $
+    by rw [← sin_arcsin (le_of_lt (neg_one_lt_div_sqrt_one_add _))
+        (le_of_lt (div_sqrt_one_add_lt_one _)), ← arctan, ← h, sin_neg, sin_pi_div_two])
+
+lemma tan_surjective : function.surjective tan :=
+function.surjective_of_has_right_inverse ⟨_, tan_arctan⟩
+
+lemma arctan_tan {x : ℝ} (hx₁ : -(π / 2) < x) (hx₂ : x < π / 2) : arctan (tan x) = x :=
+tan_inj_of_lt_of_lt_pi_div_two (neg_pi_div_two_lt_arctan _)
+  (arctan_lt_pi_div_two _) hx₁ hx₂ (by rw tan_arctan)
+
+@[simp] lemma arctan_zero : arctan 0 = 0 :=
+by simp [arctan]
+
+@[simp] lemma arctan_neg (x : ℝ) : arctan (-x) = - arctan x :=
+by simp [arctan, neg_div]
+
+end real
+
+namespace complex
+
+local notation `π` := real.pi
+
+/-- `arg` returns values in the range (-π, π], such that for `x ≠ 0`,
+  `sin (arg x) = x.im / x,abs` and `cos (arg x) = x.re / x.abs`,
+  `arg 0` defaults to `0` -/
+noncomputable def arg (x : ℂ) : ℝ :=
+if 0 ≤ x.re
+then real.arcsin (x.im / x.abs)
+else if 0 ≤ x.im
+then real.arcsin ((-x).im / x.abs) + π
+else real.arcsin ((-x).im / x.abs) - π
+
+lemma arg_le_pi (x : ℂ) : arg x ≤ π :=
+if hx₁ : 0 ≤ x.re
+then by rw [arg, if_pos hx₁];
+  exact le_trans (real.arcsin_le_pi_div_two _) (le_of_lt (half_lt_self real.pi_pos))
+else
+  have hx : x ≠ 0, from λ h, by simpa [h, lt_irrefl] using hx₁,
+  if hx₂ : 0 ≤ x.im
+  then by rw [arg, if_neg hx₁, if_pos hx₂];
+    exact le_sub_iff_add_le.1 (by rw sub_self;
+      exact real.arcsin_nonpos (by rw [neg_im, neg_div, neg_nonpos]; exact div_nonneg hx₂ (abs_pos.2 hx)))
+  else by rw [arg, if_neg hx₁, if_neg hx₂];
+      exact sub_le_iff_le_add.2 (le_trans (real.arcsin_le_pi_div_two _)
+        (by linarith using [real.pi_pos]))
+
+lemma neg_pi_lt_arg (x : ℂ) : -π < arg x :=
+if hx₁ : 0 ≤ x.re
+then by rw [arg, if_pos hx₁];
+  exact lt_of_lt_of_le (neg_lt_neg (half_lt_self real.pi_pos)) (real.neg_pi_div_two_le_arcsin _)
+else
+  have hx : x ≠ 0, from λ h, by simpa [h, lt_irrefl] using hx₁,
+  if hx₂ : 0 ≤ x.im
+  then by rw [arg, if_neg hx₁, if_pos hx₂];
+    exact sub_lt_iff_lt_add.1
+      (lt_of_lt_of_le (by linarith using [real.pi_pos]) (real.neg_pi_div_two_le_arcsin _))
+  else by rw [arg, if_neg hx₁, if_neg hx₂];
+    exact lt_sub_iff_add_lt.2 (by rw neg_add_self;
+      exact real.arcsin_pos (by rw [neg_im]; exact div_pos (neg_pos.2 (lt_of_not_ge hx₂))
+        (abs_pos.2 hx)) (by rw [← abs_neg x]; exact (abs_le.1 (abs_im_div_abs_le_one _)).2))
+
+lemma arg_eq_arg_neg_add_pi_of_im_nonneg_of_re_neg {x : ℂ} (hxr : x.re < 0) (hxi : 0 ≤ x.im) :
+  arg x = arg (-x) + π :=
+have 0 ≤ (-x).re, from le_of_lt $ by simpa [neg_pos],
+by rw [arg, arg, if_neg (not_le.2 hxr), if_pos this, if_pos hxi, abs_neg]
+
+lemma arg_eq_arg_neg_sub_pi_of_im_neg_of_re_neg {x : ℂ} (hxr : x.re < 0) (hxi : x.im < 0) :
+  arg x = arg (-x) - π :=
+have 0 ≤ (-x).re, from le_of_lt $ by simpa [neg_pos],
+by rw [arg, arg, if_neg (not_le.2 hxr), if_neg (not_le.2 hxi), if_pos this, abs_neg]
+
+@[simp] lemma arg_zero : arg 0 = 0 :=
+by simp [arg, le_refl]
+
+@[simp] lemma arg_one : arg 1 = 0 :=
+by simp [arg, zero_le_one]
+
+@[simp] lemma arg_neg_one : arg (-1) = π :=
+by simp [arg, le_refl, not_le.2 (@zero_lt_one ℝ _)]
+
+@[simp] lemma arg_I : arg I = π / 2 :=
+by simp [arg, le_refl]
+
+@[simp] lemma arg_neg_I : arg (-I) = -(π / 2) :=
+by simp [arg, le_refl]
+
+lemma sin_arg (x : ℂ) : real.sin (arg x) = x.im / x.abs :=
+by unfold arg; split_ifs;
+  simp [arg, real.sin_arcsin (abs_le.1 (abs_im_div_abs_le_one x)).1
+    (abs_le.1 (abs_im_div_abs_le_one x)).2, real.sin_add, neg_div, real.arcsin_neg,
+    real.sin_neg]
+
+private lemma cos_arg_of_re_nonneg {x : ℂ} (hx : x ≠ 0) (hxr : 0 ≤ x.re) : real.cos (arg x) = x.re / x.abs :=
+have 0 ≤ 1 - (x.im / abs x) ^ 2,
+  from sub_nonneg.2 $ by rw [pow_two, ← _root_.abs_mul_self, _root_.abs_mul, ← pow_two];
+  exact pow_le_one _ (_root_.abs_nonneg _) (abs_im_div_abs_le_one _),
+by rw [eq_div_iff_mul_eq _ _ (mt abs_eq_zero.1 hx), ← real.mul_self_sqrt (abs_nonneg x),
+    arg, if_pos hxr, real.cos_arcsin (abs_le.1 (abs_im_div_abs_le_one x)).1
+    (abs_le.1 (abs_im_div_abs_le_one x)).2, ← real.sqrt_mul (abs_nonneg _), ← real.sqrt_mul this,
+    sub_mul, div_pow _ (mt abs_eq_zero.1 hx), ← pow_two, div_mul_cancel _ (pow_ne_zero 2 (mt abs_eq_zero.1 hx)),
+    one_mul, pow_two, mul_self_abs, norm_sq, pow_two, add_sub_cancel, real.sqrt_mul_self hxr]
+
+lemma cos_arg {x : ℂ} (hx : x ≠ 0) : real.cos (arg x) = x.re / x.abs :=
+if hxr : 0 ≤ x.re then cos_arg_of_re_nonneg hx hxr
+else
+  have 0 ≤ (-x).re, from le_of_lt $ by simpa [neg_pos] using hxr,
+  if hxi : 0 ≤ x.im
+  then have 0 ≤ (-x).re, from le_of_lt $ by simpa [neg_pos] using hxr,
+    by rw [arg_eq_arg_neg_add_pi_of_im_nonneg_of_re_neg (not_le.1 hxr) hxi, real.cos_add_pi,
+        cos_arg_of_re_nonneg (neg_ne_zero.2 hx) this];
+      simp [neg_div]
+  else by rw [arg_eq_arg_neg_sub_pi_of_im_neg_of_re_neg (not_le.1 hxr) (not_le.1 hxi)];
+    simp [real.cos_add, neg_div, cos_arg_of_re_nonneg (neg_ne_zero.2 hx) this]
+
+lemma tan_arg {x : ℂ} : real.tan (arg x) = x.im / x.re :=
+if hx : x = 0 then by simp [hx]
+else by rw [real.tan_eq_sin_div_cos, sin_arg, cos_arg hx,
+    div_div_div_cancel_right _ _ (mt abs_eq_zero.1 hx)]
+
+lemma arg_cos_add_sin_mul_I {x : ℝ} (hx₁ : -π < x) (hx₂ : x ≤ π) :
+  arg (cos x + sin x * I) = x :=
+if hx₃ : -(π / 2) ≤ x ∧ x ≤ π / 2
+then
+  have hx₄ : 0 ≤ (cos x + sin x * I).re,
+    by simp; exact real.cos_nonneg_of_neg_pi_div_two_le_of_le_pi_div_two hx₃.1 hx₃.2,
+  by rw [arg, if_pos hx₄];
+    simp [abs_cos_add_sin_mul_I, sin_of_real_re, real.arcsin_sin hx₃.1 hx₃.2]
+else if hx₄ : x < -(π / 2)
+then
+  have hx₅ : ¬0 ≤ (cos x + sin x * I).re :=
+    suffices ¬ 0 ≤ real.cos x, by simpa,
+    not_le.2 $ by rw ← real.cos_neg;
+      apply real.cos_neg_of_pi_div_two_lt_of_lt; linarith,
+  have hx₆ : ¬0 ≤ (cos ↑x + sin ↑x * I).im :=
+    suffices real.sin x < 0, by simpa,
+    by apply real.sin_neg_of_neg_of_neg_pi_lt; linarith,
+  suffices -π + -real.arcsin (real.sin x) = x,
+    by rw [arg, if_neg hx₅, if_neg hx₆];
+    simpa [abs_cos_add_sin_mul_I, sin_of_real_re],
+  by rw [← real.arcsin_neg, ← real.sin_add_pi, real.arcsin_sin]; simp; linarith
+else
+  have hx₅ : π / 2 < x, by cases not_and_distrib.1 hx₃; linarith,
+  have hx₆ : ¬0 ≤ (cos x + sin x * I).re :=
+    suffices ¬0 ≤ real.cos x, by simpa,
+    not_le.2 $ by apply real.cos_neg_of_pi_div_two_lt_of_lt; linarith,
+  have hx₇ : 0 ≤ (cos x + sin x * I).im :=
+    suffices 0 ≤ real.sin x, by simpa,
+    by apply real.sin_nonneg_of_nonneg_of_le_pi; linarith,
+  suffices π - real.arcsin (real.sin x) = x,
+    by rw [arg, if_neg hx₆, if_pos hx₇];
+      simpa [abs_cos_add_sin_mul_I, sin_of_real_re],
+  by rw [← real.sin_pi_sub, real.arcsin_sin]; simp; linarith
+
+lemma arg_eq_arg_iff {x y : ℂ} (hx : x ≠ 0) (hy : y ≠ 0) :
+  arg x = arg y ↔ (abs y / abs x : ℂ) * x = y :=
+have hax : abs x ≠ 0, from (mt abs_eq_zero.1 hx),
+have hay : abs y ≠ 0, from (mt abs_eq_zero.1 hy),
+⟨λ h,
+  begin
+    have hcos := congr_arg real.cos h,
+    rw [cos_arg hx, cos_arg hy, div_eq_div_iff hax hay] at hcos,
+    have hsin := congr_arg real.sin h,
+    rw [sin_arg, sin_arg, div_eq_div_iff hax hay] at hsin,
+    apply complex.ext,
+    { rw [mul_re, ← of_real_div, of_real_re, of_real_im, zero_mul, sub_zero, mul_comm,
+        ← mul_div_assoc, hcos, mul_div_cancel _ hax] },
+    { rw [mul_im, ← of_real_div, of_real_re, of_real_im, zero_mul, add_zero,
+        mul_comm, ← mul_div_assoc, hsin, mul_div_cancel _ hax] }
+  end,
+λ h,
+  have hre : abs (y / x) * x.re = y.re,
+    by rw ← of_real_div at h;
+      simpa [-of_real_div] using congr_arg re h,
+  have hre' : abs (x / y) * y.re = x.re,
+    by rw [← hre, abs_div, abs_div, ← mul_assoc, div_mul_div,
+      mul_comm (abs _), div_self (mul_ne_zero hay hax), one_mul],
+  have him : abs (y / x) * x.im = y.im,
+    by rw ← of_real_div at h;
+      simpa [-of_real_div] using congr_arg im h,
+  have him' : abs (x / y) * y.im = x.im,
+    by rw [← him, abs_div, abs_div, ← mul_assoc, div_mul_div,
+      mul_comm (abs _), div_self (mul_ne_zero hay hax), one_mul],
+  have hxya : x.im / abs x = y.im / abs y,
+    by rw [← him, abs_div, mul_comm, ← mul_div_comm, mul_div_cancel_left _ hay],
+  have hnxya : (-x).im / abs x = (-y).im / abs y,
+    by rw [neg_im, neg_im, neg_div, neg_div, hxya],
+  if hxr : 0 ≤ x.re
+  then
+    have hyr : 0 ≤ y.re, from hre ▸ mul_nonneg (abs_nonneg _) hxr,
+    by simp [arg, *] at *
+  else
+    have hyr : ¬ 0 ≤ y.re, from λ hyr, hxr $ hre' ▸ mul_nonneg (abs_nonneg _) hyr,
+    if hxi : 0 ≤ x.im
+    then
+      have hyi : 0 ≤ y.im, from him ▸ mul_nonneg (abs_nonneg _) hxi,
+      by simp [arg, *] at *
+    else
+      have hyi : ¬ 0 ≤ y.im, from λ hyi, hxi $ him' ▸ mul_nonneg (abs_nonneg _) hyi,
+      by simp [arg, *] at *⟩
+
+lemma arg_real_mul (x : ℂ) {r : ℝ} (hr : 0 < r) : arg (r * x) = arg x :=
+if hx : x = 0 then by simp [hx]
+else (arg_eq_arg_iff (mul_ne_zero (of_real_ne_zero.2 (ne_of_lt hr).symm) hx) hx).2 $
+  by rw [abs_mul, abs_of_nonneg (le_of_lt hr), ← mul_assoc,
+    of_real_mul, mul_comm (r : ℂ), ← div_div_eq_div_mul,
+    div_mul_cancel _ (of_real_ne_zero.2 (ne_of_lt hr).symm),
+    div_self (of_real_ne_zero.2 (mt abs_eq_zero.1 hx)), one_mul]
+
+lemma ext_abs_arg {x y : ℂ} (h₁ : x.abs = y.abs) (h₂ : x.arg = y.arg) : x = y :=
+if hy : y = 0 then by simp * at *
+else have hx : x ≠ 0, from λ hx, by simp [*, eq_comm] at *,
+  by rwa [arg_eq_arg_iff hx hy, h₁, div_self (of_real_ne_zero.2 (mt abs_eq_zero.1 hy)), one_mul] at h₂
+
+lemma arg_of_real_of_nonneg {x : ℝ} (hx : 0 ≤ x) : arg x = 0 :=
+by simp [arg, hx]
+
+lemma arg_of_real_of_neg {x : ℝ} (hx : x < 0) : arg x = π :=
+by rw [arg_eq_arg_neg_add_pi_of_im_nonneg_of_re_neg, ← of_real_neg, arg_of_real_of_nonneg];
+  simp [*, le_iff_eq_or_lt, lt_neg]
+
+/-- Inverse of the `exp` function. Returns values such that `(log x).im > - π` and `(log x).im ≤ π`.
+  `log 0 = 0`-/
+noncomputable def log (x : ℂ) : ℂ := x.abs.log + arg x * I
+
+lemma log_re (x : ℂ) : x.log.re = x.abs.log := by simp [log]
+
+lemma log_im (x : ℂ) : x.log.im = x.arg := by simp [log]
+
+lemma exp_log {x : ℂ} (hx : x ≠ 0) : exp (log x) = x :=
+by rw [log, exp_add_mul_I, ← of_real_sin, sin_arg, ← of_real_cos, cos_arg hx,
+  ← of_real_exp, real.exp_log (abs_pos.2 hx), mul_add, of_real_div, of_real_div,
+  mul_div_cancel' _ (of_real_ne_zero.2 (mt abs_eq_zero.1 hx)), ← mul_assoc,
+  mul_div_cancel' _ (of_real_ne_zero.2 (mt abs_eq_zero.1 hx)), re_add_im]
+
+lemma exp_inj_of_neg_pi_lt_of_le_pi {x y : ℂ} (hx₁ : -π < x.im) (hx₂ : x.im ≤ π)
+  (hy₁ : - π < y.im) (hy₂ : y.im ≤ π) (hxy : exp x = exp y) : x = y :=
+by rw [exp_eq_exp_re_mul_sin_add_cos, exp_eq_exp_re_mul_sin_add_cos y] at hxy;
+  exact complex.ext
+    (real.exp_injective $
+      by simpa [abs_mul, abs_cos_add_sin_mul_I] using congr_arg complex.abs hxy)
+    (by simpa [(of_real_exp _).symm, - of_real_exp, arg_real_mul _ (real.exp_pos _),
+      arg_cos_add_sin_mul_I hx₁ hx₂, arg_cos_add_sin_mul_I hy₁ hy₂] using congr_arg arg hxy)
+
+lemma log_exp {x : ℂ} (hx₁ : -π < x.im) (hx₂: x.im ≤ π) : log (exp x) = x :=
+exp_inj_of_neg_pi_lt_of_le_pi
+  (by rw log_im; exact neg_pi_lt_arg _)
+  (by rw log_im; exact arg_le_pi _)
+  hx₁ hx₂ (by rw [exp_log (exp_ne_zero _)])
+
+lemma of_real_log {x : ℝ} (hx : 0 ≤ x) : (x.log : ℂ) = log x :=
+complex.ext
+  (by rw [log_re, of_real_re, abs_of_nonneg hx])
+  (by rw [of_real_im, log_im, arg_of_real_of_nonneg hx])
+
+@[simp] lemma log_zero : log 0 = 0 := by simp [log]
+
+@[simp] lemma log_one : log 1 = 0 := by simp [log]
+
+lemma log_neg_one : log (-1) = π * I := by simp [log]
+
+lemma log_I : log I = π / 2 * I := by simp [log]
+
+lemma log_neg_I : log (-I) = -(π / 2) * I := by simp [log]
+
+@[simp] lemma cos_pi_div_two : cos (π / 2) = 0 :=
+calc cos (π / 2) = real.cos (π / 2) : by rw [of_real_cos]; simp
+... = 0 : by simp
+
+@[simp] lemma sin_pi_div_two : sin (π / 2) = 1 :=
+calc sin (π / 2) = real.sin (π / 2) : by rw [of_real_sin]; simp
+... = 1 : by simp
+
+@[simp] lemma sin_pi : sin π = 0 :=
+by rw [← of_real_sin, real.sin_pi]; simp
+
+@[simp] lemma cos_pi : cos π = -1 :=
+by rw [← of_real_cos, real.cos_pi]; simp
+
+@[simp] lemma sin_two_pi : sin (2 * π) = 0 :=
+by simp [two_mul, sin_add]
+
+@[simp] lemma cos_two_pi : cos (2 * π) = 1 :=
+by simp [two_mul, cos_add]
+
+lemma sin_add_pi (x : ℝ) : sin (x + π) = -sin x :=
+by simp [sin_add]
+
+lemma sin_add_two_pi (x : ℝ) : sin (x + 2 * π) = sin x :=
+by simp [sin_add_pi, sin_add, sin_two_pi, cos_two_pi]
+
+lemma cos_add_two_pi (x : ℝ) : cos (x + 2 * π) = cos x :=
+by simp [cos_add, cos_two_pi, sin_two_pi]
+
+lemma sin_pi_sub (x : ℝ) : sin (π - x) = sin x :=
+by simp [sin_add]
+
+lemma cos_add_pi (x : ℝ) : cos (x + π) = -cos x :=
+by simp [cos_add]
+
+lemma cos_pi_sub (x : ℝ) : cos (π - x) = -cos x :=
+by simp [cos_add]
+
+lemma sin_add_pi_div_two (x : ℝ) : sin (x + π / 2) = cos x :=
+by simp [sin_add]
+
+lemma sin_sub_pi_div_two (x : ℝ) : sin (x - π / 2) = -cos x :=
+by simp [sin_add]
+
+lemma sin_pi_div_two_sub (x : ℝ) : sin (π / 2 - x) = cos x :=
+by simp [sin_add]
+
+lemma cos_add_pi_div_two (x : ℝ) : cos (x + π / 2) = -sin x :=
+by simp [cos_add]
+
+lemma cos_sub_pi_div_two (x : ℝ) : cos (x - π / 2) = sin x :=
+by simp [cos_add]
+
+lemma cos_pi_div_two_sub (x : ℝ) : cos (π / 2 - x) = sin x :=
+by rw [← cos_neg, neg_sub, cos_sub_pi_div_two]
+
+lemma sin_nat_mul_pi (n : ℕ) : sin (n * π) = 0 :=
+by induction n; simp [add_mul, sin_add, *]
+
+lemma sin_int_mul_pi (n : ℤ) : sin (n * π) = 0 :=
+by cases n; simp [add_mul, sin_add, *, sin_nat_mul_pi]
+
+lemma cos_nat_mul_two_pi (n : ℕ) : cos (n * (2 * π)) = 1 :=
+by induction n; simp [*, mul_add, cos_add, add_mul, cos_two_pi, sin_two_pi]
+
+lemma cos_int_mul_two_pi (n : ℤ) : cos (n * (2 * π)) = 1 :=
+by cases n; simp only [cos_nat_mul_two_pi, int.of_nat_eq_coe,
+  int.neg_succ_of_nat_coe, int.cast_coe_nat, int.cast_neg,
+  (neg_mul_eq_neg_mul _ _).symm, cos_neg]
+
+lemma cos_int_mul_two_pi_add_pi (n : ℤ) : cos (n * (2 * π) + π) = -1 :=
+by simp [cos_add, sin_add, cos_int_mul_two_pi]
+
+end complex

--- a/analysis/real.lean
+++ b/analysis/real.lean
@@ -21,7 +21,7 @@ generalizations:
 * Archimedean fields
 
 -/
-import logic.function analysis.metric_space
+import logic.function analysis.metric_space tactic.linarith
 
 noncomputable theory
 open classical set lattice filter topological_space
@@ -172,7 +172,7 @@ let ⟨δ, δ0, Hδ⟩ := rat_mul_continuous_lemma abs ε0 r₁0 r₂0 in
 ⟨δ, δ0, λ a b h,
   let ⟨h₁, h₂⟩ := max_lt_iff.1 h in Hδ (H _ a.2).1 (H _ b.2).2 h₁ h₂⟩
 
-lemma real.continuous_mul : continuous (λp : ℝ × ℝ, p.1 * p.2) :=
+protected lemma real.continuous_mul : continuous (λp : ℝ × ℝ, p.1 * p.2) :=
 continuous_iff_tendsto.2 $ λ ⟨a₁, a₂⟩,
 tendsto_of_uniform_continuous_subtype
   (real.uniform_continuous_mul
@@ -318,5 +318,59 @@ lemma compact_Icc {a b : ℝ} : compact (Icc a b) :=
 compact_of_totally_bounded_is_closed
   (real.totally_bounded_Icc a b)
   (is_closed_inter (is_closed_ge' a) (is_closed_le' b))
+
+open real
+
+lemma real.intermediate_value {f : ℝ → ℝ} {a b t : ℝ}
+  (hf : ∀ x, a ≤ x → x ≤ b → tendsto f (nhds x) (nhds (f x)))
+  (ha : f a ≤ t) (hb : t ≤ f b) (hab : a ≤ b) : ∃ x : ℝ, a ≤ x ∧ x ≤ b ∧ f x = t :=
+let x := real.Sup {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b} in
+have hx₁ : ∃ y, ∀ g ∈ {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b}, g ≤ y := ⟨b, λ _ h, h.2.2⟩,
+have hx₂ : ∃ y, y ∈ {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b} := ⟨a, ha, le_refl _, hab⟩,
+have hax : a ≤ x, from le_Sup _ hx₁ ⟨ha, le_refl _, hab⟩,
+have hxb : x ≤ b, from (Sup_le _ hx₂ hx₁).2 (λ _ h, h.2.2),
+⟨x, hax, hxb,
+  eq_of_forall_dist_le $ λ ε ε0,
+    let ⟨δ, hδ0, hδ⟩ := tendsto_nhds_of_metric.1 (hf _ hax hxb) ε ε0 in
+    (le_total t (f x)).elim
+      (λ h, le_of_not_gt $ λ hfε, begin
+        rw [dist_eq, abs_of_nonneg (sub_nonneg.2 h)] at hfε,
+        refine mt (Sup_le {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b} hx₂ hx₁).2
+          (not_le_of_gt (sub_lt_self x (half_pos hδ0)))
+          (λ g hg, le_of_not_gt
+            (λ hgδ, not_lt_of_ge hg.1
+              (lt_trans (lt_sub.1 hfε) (sub_lt_of_sub_lt
+                (lt_of_le_of_lt (le_abs_self _) _))))),
+        rw abs_sub,
+        exact hδ (abs_sub_lt_iff.2 ⟨lt_of_le_of_lt (sub_nonpos.2 (le_Sup _ hx₁ hg)) hδ0,
+          by simp only [x] at *; linarith⟩)
+        end)
+      (λ h, le_of_not_gt $ λ hfε, begin
+        rw [dist_eq, abs_of_nonpos (sub_nonpos.2 h)] at hfε,
+        exact mt (le_Sup {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b})
+          (λ h : ∀ k, k ∈ {x | f x ≤ t ∧ a ≤ x ∧ x ≤ b} → k ≤ x,
+            not_le_of_gt ((lt_add_iff_pos_left x).2 (half_pos hδ0))
+              (h _ ⟨le_trans (le_sub_iff_add_le.2 (le_trans (le_abs_self _)
+                    (le_of_lt (hδ $ by rw [dist_eq, add_sub_cancel, abs_of_nonneg (le_of_lt (half_pos hδ0))];
+                      exact half_lt_self hδ0))))
+                  (by linarith),
+                le_trans hax (le_of_lt ((lt_add_iff_pos_left _).2 (half_pos hδ0))),
+                le_of_not_gt (λ hδy, not_lt_of_ge hb (lt_of_le_of_lt
+                  (show f b ≤ f b - f x - ε + t, by linarith)
+                  (add_lt_of_neg_of_le
+                    (sub_neg_of_lt (lt_of_le_of_lt (le_abs_self _)
+                      (@hδ b (abs_sub_lt_iff.2 ⟨by simp only [x] at *; linarith,
+                        by linarith⟩))))
+                    (le_refl _))))⟩))
+          hx₁
+        end)⟩
+
+lemma real.intermediate_value' {f : ℝ → ℝ} {a b t : ℝ}
+  (hf : ∀ x, a ≤ x → x ≤ b → tendsto f (nhds x) (nhds (f x)))
+  (ha : t ≤ f a) (hb : f b ≤ t) (hab : a ≤ b) : ∃ x : ℝ, a ≤ x ∧ x ≤ b ∧ f x = t :=
+let ⟨x, hx₁, hx₂, hx₃⟩ := @real.intermediate_value
+  (λ x, - f x) a b (-t) (λ x hax hxb, tendsto_neg (hf x hax hxb))
+  (neg_le_neg ha) (neg_le_neg hb) hab in
+⟨x, hx₁, hx₂, neg_inj hx₃⟩
 
 end

--- a/data/complex/basic.lean
+++ b/data/complex/basic.lean
@@ -38,7 +38,7 @@ instance : inhabited ℂ := ⟨0⟩
 
 @[simp] lemma zero_re : (0 : ℂ).re = 0 := rfl
 @[simp] lemma zero_im : (0 : ℂ).im = 0 := rfl
-lemma of_real_zero : ((0 : ℝ) : ℂ) = 0 := rfl
+@[simp] lemma of_real_zero : ((0 : ℝ) : ℂ) = 0 := rfl
 
 @[simp] theorem of_real_eq_zero {z : ℝ} : (z : ℂ) = 0 ↔ z = 0 := of_real_inj
 @[simp] theorem of_real_ne_zero {z : ℝ} : (z : ℂ) ≠ 0 ↔ z ≠ 0 := not_congr of_real_eq_zero
@@ -75,6 +75,8 @@ instance : has_mul ℂ := ⟨λ z w, ⟨z.re * w.re - z.im * w.im, z.re * w.im +
 @[simp] lemma mul_im (z w : ℂ) : (z * w).im = z.re * w.im + z.im * w.re := rfl
 @[simp] lemma of_real_mul (r s : ℝ) : ((r * s : ℝ) : ℂ) = r * s := ext_iff.2 $ by simp
 
+@[simp] lemma I_mul_I : I * I = -1 := rfl
+
 lemma mk_eq_add_mul_I (a b : ℝ) : complex.mk a b = a + b * I :=
 ext_iff.2 $ by simp
 
@@ -91,6 +93,7 @@ def conj (z : ℂ) : ℂ := ⟨z.re, -z.im⟩
 @[simp] lemma conj_zero : conj 0 = 0 := rfl
 @[simp] lemma conj_one : conj 1 = 1 := rfl
 @[simp] lemma conj_I : conj I = -I := rfl
+@[simp] lemma conj_neg_I : conj (-I) = I := rfl
 
 @[simp] lemma conj_add (z w : ℂ) : conj (z + w) = conj z + conj w :=
 ext_iff.2 $ by simp
@@ -167,12 +170,24 @@ instance : comm_ring ℂ :=
 by refine { zero := 0, add := (+), neg := has_neg.neg, one := 1, mul := (*), ..};
    { intros, apply ext_iff.2; split; simp; ring }
 
+@[simp] lemma bit0_re (z : ℂ) : (bit0 z).re = bit0 z.re := rfl
+@[simp] lemma bit1_re (z : ℂ) : (bit1 z).re = bit1 z.re := rfl
+@[simp] lemma bit0_im (z : ℂ) : (bit0 z).im = bit0 z.im := eq.refl _
+@[simp] lemma bit1_im (z : ℂ) : (bit1 z).im = bit0 z.im := add_zero _
+
 @[simp] lemma sub_re (z w : ℂ) : (z - w).re = z.re - w.re := rfl
 @[simp] lemma sub_im (z w : ℂ) : (z - w).im = z.im - w.im := rfl
 @[simp] lemma of_real_sub (r s : ℝ) : ((r - s : ℝ) : ℂ) = r - s := rfl
+@[simp] lemma of_real_pow (r : ℝ) (n : ℕ) : ((r ^ n : ℝ) : ℂ) = r ^ n :=
+by induction n; simp [*, of_real_mul, pow_succ]
 
 theorem sub_conj (z : ℂ) : z - conj z = (2 * z.im : ℝ) * I :=
 ext_iff.2 $ by simp [two_mul]
+
+lemma conj_pow (z : ℂ) (n : ℕ) : conj (z ^ n) = conj z ^ n :=
+by induction n; simp [*, conj_mul, pow_succ]
+
+@[simp] lemma conj_two : conj (2 : ℂ) = 2 := by apply complex.ext; simp
 
 lemma norm_sq_sub (z w : ℂ) : norm_sq (z - w) =
   norm_sq z + norm_sq w - 2 * (z * conj w).re :=
@@ -221,6 +236,9 @@ if h : z = 0 then by simp [h] else
 (domain.mul_left_inj (mt conj_eq_zero.1 h)).1 $
 by rw [← conj_mul]; simp [h, -conj_mul]
 
+@[simp] lemma conj_sub (z w : ℂ) : conj (z - w) = conj z - conj w :=
+by simp
+
 @[simp] lemma conj_div (z w : ℂ) : conj (z / w) = conj z / conj w :=
 by rw [division_def, conj_mul, conj_inv]; refl
 
@@ -258,6 +276,10 @@ real.mul_self_sqrt (norm_sq_nonneg _)
 @[simp] lemma abs_zero : abs 0 = 0 := by simp [abs]
 @[simp] lemma abs_one : abs 1 = 1 := by simp [abs]
 @[simp] lemma abs_I : abs I = 1 := by simp [abs]
+
+@[simp] lemma abs_two : abs 2 = 2 :=
+calc abs 2 = abs (2 : ℝ) : by rw [of_real_bit0, of_real_one]
+... = (2 : ℝ) : abs_of_nonneg (by norm_num)
 
 lemma abs_nonneg (z : ℂ) : 0 ≤ abs z :=
 real.sqrt_nonneg _
@@ -318,6 +340,22 @@ lemma abs_abs_sub_le_abs_sub : ∀ z w, abs' (abs z - abs w) ≤ abs (z - w) := 
 lemma abs_le_abs_re_add_abs_im (z : ℂ) : abs z ≤ abs' z.re + abs' z.im :=
 by simpa [re_add_im] using abs_add z.re (z.im * I)
 
+lemma abs_re_div_abs_le_one (z : ℂ) : abs' (z.re / z.abs) ≤ 1 :=
+if hz : z = 0 then by simp [hz, zero_le_one]
+else by rw [_root_.abs_div, abs_abs]; exact
+  div_le_of_le_mul (abs_pos.2 hz) (by rw mul_one; exact abs_re_le_abs _)
+
+lemma abs_im_div_abs_le_one (z : ℂ) : abs' (z.im / z.abs) ≤ 1 :=
+if hz : z = 0 then by simp [hz, zero_le_one]
+else by rw [_root_.abs_div, abs_abs]; exact
+  div_le_of_le_mul (abs_pos.2 hz) (by rw mul_one; exact abs_im_le_abs _)
+
+@[simp] lemma abs_cast_nat (n : ℕ) : abs (n : ℂ) = n :=
+by rw [← of_real_nat_cast, abs_of_nonneg (nat.cast_nonneg n)]
+
+lemma norm_sq_eq_abs (x : ℂ) : norm_sq x = abs x ^ 2 :=
+by rw [abs, pow_two, real.mul_self_sqrt (norm_sq_nonneg _)]
+
 noncomputable def lim (f : ℕ → ℂ) : ℂ :=
 ⟨real.lim (λ n, (f n).re), real.lim (λ n, (f n).im)⟩
 
@@ -329,6 +367,11 @@ theorem is_cau_seq_im (f : cau_seq ℂ abs) : is_cau_seq abs' (λ n, (f n).im) :
 λ ε ε0, (f.cauchy ε0).imp $ λ i H j ij,
 lt_of_le_of_lt (by simpa using abs_im_le_abs (f j - f i)) (H _ ij)
 
+lemma is_cau_seq_abs {f : ℕ → ℂ} (hf : is_cau_seq abs f) :
+  is_cau_seq abs' (abs ∘ f) :=
+λ ε ε0, let ⟨i, hi⟩ := hf ε ε0 in
+⟨i, λ j hj, lt_of_le_of_lt (abs_abs_sub_le_abs_sub _ _) (hi j hj)⟩
+
 theorem equiv_lim (f : cau_seq ℂ abs) : f ≈ cau_seq.const abs (lim f) :=
 λ ε ε0, (exists_forall_ge_and
   (real.equiv_lim ⟨_, is_cau_seq_re f⟩ _ (half_pos ε0))
@@ -338,5 +381,99 @@ theorem equiv_lim (f : cau_seq ℂ abs) : f ≈ cau_seq.const abs (lim f) :=
   apply lt_of_le_of_lt (abs_le_abs_re_add_abs_im _),
   simpa using add_lt_add H₁ H₂
 end
+
+open cau_seq
+
+lemma re_const_equiv_of_const_equiv {f : cau_seq ℂ abs} (z : ℂ)
+  (h : const abs z ≈ f) :
+  const _root_.abs z.re ≈ ⟨(λ (n : ℕ), (f n).re), is_cau_seq_re f⟩  :=
+λ ε ε0, let ⟨i, hi⟩ := h ε ε0 in
+⟨i, λ j hji, show abs' (z.re - (f j).re) < ε,
+  by rw ← sub_re; exact lt_of_le_of_lt (abs_re_le_abs _) (hi j hji)⟩
+
+lemma im_const_equiv_of_const_equiv {f : cau_seq ℂ abs} (z : ℂ)
+  (h : const abs z ≈ f) :
+  const _root_.abs z.im ≈ ⟨(λ (n : ℕ), (f n).im), is_cau_seq_im f⟩  :=
+λ ε ε0, let ⟨i, hi⟩ := h ε ε0 in
+⟨i, λ j hji, show abs' (z.im - (f j).im) < ε,
+  by rw ← sub_im; exact lt_of_le_of_lt (abs_im_le_abs _) (hi j hji)⟩
+
+lemma eq_lim_of_const_equiv {f : cau_seq ℂ abs} {z : ℂ}
+  (h : const abs z ≈ f) : z = lim f :=
+complex.ext
+  (show z.re = real.lim (⟨complex.re ∘ f, is_cau_seq_re f⟩ : cau_seq ℝ abs'),
+    from real.eq_lim_of_const_equiv (re_const_equiv_of_const_equiv _ h))
+  (show z.im = real.lim (⟨complex.im ∘ f, is_cau_seq_im f⟩ : cau_seq ℝ abs'),
+    from real.eq_lim_of_const_equiv (im_const_equiv_of_const_equiv _ h))
+
+lemma lim_eq_of_equiv_const {f : cau_seq ℂ abs} {x : ℂ} (h : f ≈ const abs x) : lim f = x :=
+(eq_lim_of_const_equiv $ setoid.symm h).symm
+
+lemma lim_eq_lim_of_equiv {f g : cau_seq ℂ abs} (h : f ≈ g) : lim f = lim g :=
+lim_eq_of_equiv_const $ setoid.trans h $ equiv_lim g
+
+@[simp] lemma lim_const (x : ℂ) : lim (const abs x) = x :=
+lim_eq_of_equiv_const $ setoid.refl _
+
+lemma lim_add (f g : cau_seq ℂ abs) : lim f + lim g = lim ⇑(f + g) :=
+eq_lim_of_const_equiv $ show lim_zero (const abs (lim ⇑f + lim ⇑g) - (f + g)),
+  by rw [const_add, add_sub_comm];
+  exact add_lim_zero (setoid.symm (equiv_lim f)) (setoid.symm (equiv_lim g))
+
+lemma lim_mul_lim (f g : cau_seq ℂ abs) : lim f * lim g = lim ⇑(f * g) :=
+eq_lim_of_const_equiv $ show lim_zero (const abs (lim ⇑f * lim ⇑g) - f * g),
+  from have h : const abs (lim ⇑f * lim ⇑g) - f * g = g * (const abs (lim f) - f)
+      + const abs (lim f) * (const abs (lim g) - g) :=
+    by simp [mul_sub, mul_comm, const_mul, mul_add],
+  by rw h; exact add_lim_zero (mul_lim_zero _ (setoid.symm (equiv_lim f)))
+      (mul_lim_zero _ (setoid.symm (equiv_lim g)))
+
+lemma lim_mul (f : cau_seq ℂ abs) (x : ℂ) : lim f * x = lim ⇑(f * const abs x) :=
+by rw [← lim_mul_lim, lim_const]
+
+lemma lim_neg (f : cau_seq ℂ abs) : lim ⇑(-f) = -lim f :=
+lim_eq_of_equiv_const (show lim_zero (-f - const abs (-lim ⇑f)),
+  by rw [const_neg, sub_neg_eq_add, add_comm];
+  exact setoid.symm (equiv_lim f))
+
+lemma is_cau_seq_conj {f : ℕ → ℂ} (hf : is_cau_seq abs f) :
+  is_cau_seq abs (conj ∘ f) :=
+λ ε ε0, let ⟨i, hi⟩ := hf ε ε0 in
+⟨i, λ j hj, by rw [function.comp_apply, function.comp_apply, ← conj_sub, abs_conj];
+  exact hi j hj⟩
+
+lemma lim_conj (f : cau_seq ℂ abs) : lim (⟨conj ∘ f, is_cau_seq_conj f.2⟩ : cau_seq ℂ abs) = conj (lim f) :=
+complex.ext rfl (real.lim_neg ⟨_, is_cau_seq_im f⟩ : _)
+
+lemma lim_eq_zero_iff (f : cau_seq ℂ abs) : lim f = 0 ↔ lim_zero f :=
+⟨assume h,
+  by have hf := equiv_lim f;
+  rw h at hf;
+  exact (lim_zero_congr hf).mpr (const_lim_zero.mpr rfl),
+assume h,
+  have h₁ : f = (f - const abs (0 : ℂ)) := cau_seq.ext (λ n, by simp [sub_apply, const_apply]),
+  by rw h₁ at h; exact lim_eq_of_equiv_const h ⟩
+
+lemma lim_inv {f : cau_seq ℂ abs} (hf : ¬ lim_zero f) : lim ⇑(inv f hf) = (lim f)⁻¹ :=
+have hl : lim f ≠ 0 := by rwa ← lim_eq_zero_iff at hf,
+lim_eq_of_equiv_const $ show lim_zero (inv f hf - const abs (lim ⇑f)⁻¹),
+  from have h₁ : ∀ (g f : cau_seq ℂ abs) (hf : ¬ lim_zero f), lim_zero (g - f * inv f hf * g) :=
+    λ g f hf, by rw [← one_mul g, ← mul_assoc, ← sub_mul, mul_one, mul_comm, mul_comm f];
+    exact mul_lim_zero _ (setoid.symm (cau_seq.inv_mul_cancel _)),
+  have h₂ : lim_zero ((inv f hf - const abs (lim ⇑f)⁻¹) - (const abs (lim f) - f) *
+      (inv f hf * const abs (lim ⇑f)⁻¹)) :=
+    by rw [sub_mul, ← sub_add, sub_sub, sub_add_eq_sub_sub, sub_right_comm, sub_add];
+    exact show lim_zero (inv f hf - const abs (lim ⇑f) * (inv f hf * const abs (lim ⇑f)⁻¹)
+      - (const abs (lim ⇑f)⁻¹ - f * (inv f hf * const abs (lim ⇑f)⁻¹))),
+    from sub_lim_zero
+      (by rw [← mul_assoc, mul_right_comm, const_inv hl]; exact h₁ _ _ _)
+      (by rw [← mul_assoc]; exact h₁ _ _ _),
+  (lim_zero_congr h₂).mpr $ by rw mul_comm; exact mul_lim_zero _ (setoid.symm (equiv_lim f))
+
+lemma lim_abs (f : cau_seq ℂ abs) :
+  real.lim (⟨_, is_cau_seq_abs f.2⟩ : cau_seq ℝ abs') = abs (complex.lim f) :=
+real.lim_eq_of_equiv_const (λ ε ε0,
+let ⟨i, hi⟩ := equiv_lim f ε ε0 in
+⟨i, λ j hj, lt_of_le_of_lt (abs_abs_sub_le_abs_sub _ _) (hi j hj)⟩)
 
 end complex

--- a/data/complex/exponential.lean
+++ b/data/complex/exponential.lean
@@ -1,0 +1,1040 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes
+-/
+import data.complex.basic algebra.archimedean data.nat.binomial tactic.linarith
+
+local attribute [instance, priority 0] classical.prop_decidable
+local notation `abs'` := _root_.abs
+open is_absolute_value
+
+section
+open real is_absolute_value finset
+
+lemma geo_sum_eq {α : Type*} [field α] {x : α} : ∀ (n : ℕ) (hx1 : x ≠ 1),
+  (range n).sum (λ m, x ^ m) = (1 - x ^ n) / (1 - x)
+| 0     hx1 := by simp
+| (n+1) hx1 := have 1 - x ≠ 0 := mt sub_eq_zero_iff_eq.1 hx1.symm,
+by rw [sum_range_succ, ← mul_div_cancel (x ^ n) this, geo_sum_eq n hx1, ← add_div, _root_.pow_succ];
+    simp [mul_add, add_mul, mul_comm]
+
+lemma geo_sum_inv_eq {α : Type*} [discrete_field α] {x : α} (n : ℕ) (hx1 : x ≠ 1) (hx0 : x ≠ 0) :
+  (range n).sum (λ m, x⁻¹ ^ m) = (x - x * x⁻¹ ^ n) / (x - 1) :=
+have hx1' : x⁻¹ ≠ 1, from λ h, by rw [← @inv_inv' _ _ x, h] at hx1; simpa using hx1,
+have h1x' : 1 - x⁻¹ ≠ 0, from sub_ne_zero.2 hx1'.symm,
+have h1x : x - 1 ≠ 0, from sub_ne_zero.2 hx1,
+by rw [geo_sum_eq _ hx1', div_eq_div_iff h1x' h1x];
+  simp [mul_add, add_mul, mul_inv_cancel hx0, mul_comm x, mul_left_comm x,
+    mul_assoc, inv_mul_cancel hx0]
+
+lemma forall_ge_le_of_forall_le_succ {α : Type*} [preorder α] (f : ℕ → α) {m : ℕ}
+  (h : ∀ n ≥ m, f n.succ ≤ f n) : ∀ {l}, ∀ k ≥ m, k ≤ l → f l ≤ f k :=
+begin
+  assume l k hkm hkl,
+  generalize hp : l - k = p,
+  have : l = k + p := add_comm p k ▸ (nat.sub_eq_iff_eq_add hkl).1 hp,
+  subst this,
+  clear hkl hp,
+  induction p with p ih,
+  { simp },
+  { exact le_trans (h _ (le_trans hkm (nat.le_add_right _ _))) ih }
+end
+
+variables {α : Type*} {β : Type*} [ring β]
+  [discrete_linear_ordered_field α] [archimedean α] {abv : β → α} [is_absolute_value abv]
+
+lemma is_cau_of_decreasing_bounded (f : ℕ → α) {a : α} {m : ℕ} (ham : ∀ n ≥ m, abs (f n) ≤ a)
+  (hnm : ∀ n ≥ m, f n.succ ≤ f n) : is_cau_seq abs f :=
+λ ε ε0,
+let ⟨k, hk⟩ := archimedean.arch a ε0 in
+have h : ∃ l, ∀ n ≥ m, a - add_monoid.smul l ε < f n :=
+  ⟨k + k + 1, λ n hnm, lt_of_lt_of_le
+    (show a - add_monoid.smul (k + (k + 1)) ε < -abs (f n),
+      from lt_neg.1 $ lt_of_le_of_lt (ham n hnm) (begin
+        rw [neg_sub, lt_sub_iff_add_lt, add_monoid.add_smul],
+        exact add_lt_add_of_le_of_lt hk (lt_of_le_of_lt hk
+          (lt_add_of_pos_left _ ε0)),
+      end))
+    (neg_le.2 $ (abs_neg (f n)) ▸ le_abs_self _)⟩,
+let l := nat.find h in
+have hl : ∀ (n : ℕ), n ≥ m → f n > a - add_monoid.smul l ε := nat.find_spec h,
+have hl0 : l ≠ 0 := λ hl0, not_lt_of_ge (ham m (le_refl _))
+  (lt_of_lt_of_le (by have := hl m (le_refl m); simpa [hl0] using this) (le_abs_self (f m))),
+begin
+  cases classical.not_forall.1
+    (nat.find_min h (nat.pred_lt hl0)) with i hi,
+  rw [not_imp, not_lt] at hi,
+  existsi i,
+  assume j hj,
+  have hfij : f j ≤ f i := forall_ge_le_of_forall_le_succ f hnm _ hi.1 hj,
+  rw [abs_of_nonpos (sub_nonpos.2 hfij), neg_sub, sub_lt_iff_lt_add'],
+  exact calc f i ≤ a - add_monoid.smul (nat.pred l) ε : hi.2
+    ... = a - add_monoid.smul l ε + ε :
+      by conv {to_rhs, rw [← nat.succ_pred_eq_of_pos (nat.pos_of_ne_zero hl0), succ_smul',
+        sub_add, add_sub_cancel] }
+    ... < f j + ε : add_lt_add_right (hl j (le_trans hi.1 hj)) _
+end
+
+lemma is_cau_of_mono_bounded (f : ℕ → α) {a : α} {m : ℕ} (ham : ∀ n ≥ m, abs (f n) ≤ a)
+  (hnm : ∀ n ≥ m, f n ≤ f n.succ) : is_cau_seq abs f :=
+begin
+  refine @eq.rec_on (ℕ → α) _ (is_cau_seq abs) _ _
+    (-⟨_, @is_cau_of_decreasing_bounded _ _ _ (λ n, -f n) a m (by simpa) (by simpa)⟩ : cau_seq α abs).2,
+  ext,
+  exact neg_neg _
+end
+
+lemma is_cau_series_of_abv_le_cau  {f : ℕ → β} {g : ℕ → α}  (n : ℕ) : (∀ m, n ≤ m → abv (f m) ≤ g m) →
+  is_cau_seq abs (λ n, (range n).sum g) → is_cau_seq abv (λ n, (range n).sum f) :=
+begin
+  assume hm hg ε ε0,
+  cases hg (ε / 2) (div_pos ε0 (by norm_num)) with i hi,
+  existsi max n i,
+  assume j ji,
+  have hi₁ := hi j (le_trans (le_max_right n i) ji),
+  have hi₂ := hi (max n i) (le_max_right n i),
+  have sub_le := abs_sub_le ((range j).sum g) ((range i).sum g) ((range (max n i)).sum g),
+  have := add_lt_add hi₁ hi₂,
+  rw [abs_sub ((range (max n i)).sum g), add_halves ε] at this,
+  refine lt_of_le_of_lt (le_trans (le_trans _ (le_abs_self _)) sub_le) this,
+  generalize hk : j - max n i = k,
+  clear this hi₂ hi₁ hi ε0 ε hg sub_le,
+  rw nat.sub_eq_iff_eq_add ji at hk,
+  rw hk,
+  clear hk ji j,
+  induction k with k' hi,
+  { simp [abv_zero abv] },
+  { dsimp at *,
+    rw [nat.succ_add, sum_range_succ, sum_range_succ, add_assoc, add_assoc],
+    refine le_trans (abv_add _ _ _) _,
+    exact add_le_add (hm _ (le_add_of_nonneg_of_le (nat.zero_le _) (le_max_left _ _))) hi },
+end
+
+lemma is_cau_series_of_abv_cau {f : ℕ → β} : is_cau_seq abs (λ m, (range m).sum (λ n, abv (f n))) →
+  is_cau_seq abv (λ m, (range m).sum f) :=
+is_cau_series_of_abv_le_cau 0 (λ n h, le_refl _)
+
+lemma is_cau_geo_series {β : Type*} [field β] {abv : β → α} [is_absolute_value abv]
+   (x : β) (hx1 : abv x < 1) : is_cau_seq abv (λ n, (range n).sum (λ m, x ^ m)) :=
+have hx1' : abv x ≠ 1 := λ h, by simpa [h, lt_irrefl] using hx1,
+is_cau_series_of_abv_cau
+begin
+  simp only [abv_pow abv, geo_sum_eq _ hx1'] {eta := ff},
+  refine @is_cau_of_mono_bounded _ _ _ _ ((1 : α) / (1 - abv x)) 0 _ _,
+  { assume n hn,
+    rw abs_of_nonneg ,
+    refine div_le_div_of_le_of_pos (sub_le_self _ (abv_pow abv x n ▸ abv_nonneg _ _))
+      (sub_pos.2 hx1),
+    refine div_nonneg (sub_nonneg.2 _) (sub_pos.2 hx1),
+    clear hn,
+    induction n with n ih,
+    { simp },
+    { rw [_root_.pow_succ, ← one_mul (1 : α)],
+      refine mul_le_mul (le_of_lt hx1) ih (abv_pow abv x n ▸ abv_nonneg _ _) (by norm_num) } },
+  { assume n hn,
+    refine div_le_div_of_le_of_pos (sub_le_sub_left _ _) (sub_pos.2 hx1),
+    rw [← one_mul (_ ^ n), _root_.pow_succ],
+    exact mul_le_mul_of_nonneg_right (le_of_lt hx1) (pow_nonneg (abv_nonneg _ _) _) }
+end
+
+lemma is_cau_geo_series_const (a : α) {x : α} (hx1 : abs x < 1) : is_cau_seq abs (λ m, (range m).sum (λ n, a * x ^ n)) :=
+have is_cau_seq abs (λ m, a * (range m).sum (λ n, x ^ n)) := (cau_seq.const abs a * ⟨_, is_cau_geo_series x hx1⟩).2,
+  by simpa only [mul_sum]
+
+lemma series_ratio_test {f : ℕ → β} (n : ℕ) (r : α)
+  (hr0 : 0 ≤ r) (hr1 : r < 1) (h : ∀ m, n ≤ m → abv (f m.succ) ≤ r * abv (f m)) :
+  is_cau_seq abv (λ m, (range m).sum f) :=
+have har1 : abs r < 1, by rwa abs_of_nonneg hr0,
+begin
+  refine is_cau_series_of_abv_le_cau n.succ _ (is_cau_geo_series_const (abv (f n.succ) * r⁻¹ ^ n.succ) har1),
+  assume m hmn,
+  cases classical.em (r = 0) with r_zero r_ne_zero,
+  { have m_pos := lt_of_lt_of_le (nat.succ_pos n) hmn,
+    have := h m.pred (nat.le_of_succ_le_succ (by rwa [nat.succ_pred_eq_of_pos m_pos])),
+    simpa [r_zero, nat.succ_pred_eq_of_pos m_pos, pow_succ] },
+  generalize hk : m - n.succ = k,
+  have r_pos : 0 < r := lt_of_le_of_ne hr0 (ne.symm r_ne_zero),
+  replace hk : m = k + n.succ := (nat.sub_eq_iff_eq_add hmn).1 hk,
+  induction k with k ih generalizing m n,
+  { rw [hk, zero_add, mul_right_comm, ← pow_inv _ _ r_ne_zero, ← div_eq_mul_inv, mul_div_cancel],
+    exact (ne_of_lt (pow_pos r_pos _)).symm },
+  { have kn : k + n.succ ≥ n.succ, by rw ← zero_add n.succ; exact add_le_add (zero_le _) (by simp),
+    rw [hk, nat.succ_add, pow_succ' r, ← mul_assoc],
+    exact le_trans (by rw mul_comm; exact h _ (nat.le_of_succ_le kn))
+      (mul_le_mul_of_nonneg_right (ih (k + n.succ) n h kn rfl) hr0) }
+end
+
+lemma sum_range_diag_flip {α : Type*} [add_comm_monoid α] (n : ℕ) (f : ℕ → ℕ → α) :
+  (range n).sum (λ m, (range (m + 1)).sum (λ k, f k (m - k))) =
+  (range n).sum (λ m, (range (n - m)).sum (f m)) :=
+have h₁ : ((range n).sigma (range ∘ nat.succ)).sum
+    (λ (a : Σ m, ℕ), f (a.2) (a.1 - a.2)) =
+    (range n).sum (λ m, (range (m + 1)).sum
+    (λ k, f k (m - k))) := sum_sigma,
+have h₂ : ((range n).sigma (λ m, range (n - m))).sum (λ a : Σ (m : ℕ), ℕ, f (a.1) (a.2)) =
+    (range n).sum (λ m, sum (range (n - m)) (f m)) := sum_sigma,
+h₁ ▸ h₂ ▸ sum_bij
+(λ a _, ⟨a.2, a.1 - a.2⟩)
+(λ a ha, have h₁ : a.1 < n := mem_range.1 (mem_sigma.1 ha).1,
+  have h₂ : a.2 < nat.succ a.1 := mem_range.1 (mem_sigma.1 ha).2,
+    mem_sigma.2 ⟨mem_range.2 (lt_of_lt_of_le h₂ h₁),
+    mem_range.2 ((nat.sub_lt_sub_right_iff (nat.le_of_lt_succ h₂)).2 h₁)⟩)
+(λ _ _, rfl)
+(λ ⟨a₁, a₂⟩ ⟨b₁, b₂⟩ ha hb h,
+  have ha : a₁ < n ∧ a₂ ≤ a₁ :=
+      ⟨mem_range.1 (mem_sigma.1 ha).1, nat.le_of_lt_succ (mem_range.1 (mem_sigma.1 ha).2)⟩,
+  have hb : b₁ < n ∧ b₂ ≤ b₁ :=
+      ⟨mem_range.1 (mem_sigma.1 hb).1, nat.le_of_lt_succ (mem_range.1 (mem_sigma.1 hb).2)⟩,
+  have h : a₂ = b₂ ∧ _ := sigma.mk.inj h,
+  have h' : a₁ = b₁ - b₂ + a₂ := (nat.sub_eq_iff_eq_add ha.2).1 (eq_of_heq h.2),
+  sigma.mk.inj_iff.2
+    ⟨nat.sub_add_cancel hb.2 ▸ h'.symm ▸ h.1 ▸ rfl,
+      (heq_of_eq h.1)⟩)
+(λ ⟨a₁, a₂⟩ ha,
+  have ha : a₁ < n ∧ a₂ < n - a₁ :=
+      ⟨mem_range.1 (mem_sigma.1 ha).1, (mem_range.1 (mem_sigma.1 ha).2)⟩,
+  ⟨⟨a₂ + a₁, a₁⟩, ⟨mem_sigma.2 ⟨mem_range.2 (nat.lt_sub_right_iff_add_lt.1 ha.2),
+    mem_range.2 (nat.lt_succ_of_le (nat.le_add_left _ _))⟩,
+  sigma.mk.inj_iff.2 ⟨rfl, heq_of_eq (nat.add_sub_cancel _ _).symm⟩⟩⟩)
+
+lemma abv_sum_le_sum_abv {γ : Type*} (f : γ → β) (s : finset γ) :
+  abv (s.sum f) ≤ s.sum (abv ∘ f) :=
+by haveI := classical.dec_eq γ; exact
+finset.induction_on s (by simp [abv_zero abv])
+  (λ a s has ih, by rw [sum_insert has, sum_insert has];
+    exact le_trans (abv_add abv _ _) (add_le_add_left ih _))
+
+lemma sum_range_sub_sum_range {α : Type*} [add_comm_group α] {f : ℕ → α}
+  {n m : ℕ} (hnm : n ≤ m) : (range m).sum f - (range n).sum f =
+  ((range m).filter (λ k, n ≤ k)).sum f :=
+begin
+  rw [← sum_sdiff (@filter_subset _ (λ k, n ≤ k) _ (range m)),
+    sub_eq_iff_eq_add, ← eq_sub_iff_add_eq, add_sub_cancel'],
+  refine finset.sum_congr
+    (finset.ext.2 $ λ a, ⟨λ h, by simp at *; finish,
+    λ h, have ham : a < m := lt_of_lt_of_le (mem_range.1 h) hnm,
+      by simp * at *⟩)
+    (λ _ _, rfl),
+end
+
+lemma cauchy_product {a b : ℕ → β}
+  (ha : is_cau_seq abs (λ m, (range m).sum (λ n, abv (a n))))
+  (hb : is_cau_seq abv (λ m, (range m).sum b)) (ε : α) (ε0 : 0 < ε) :
+  ∃ i : ℕ, ∀ j ≥ i, abv ((range j).sum a * (range j).sum b -
+  (range j).sum (λ n, (range (n + 1)).sum (λ m, a m * b (n - m)))) < ε :=
+let ⟨Q, hQ⟩ := cau_seq.bounded ⟨_, hb⟩ in
+let ⟨P, hP⟩ := cau_seq.bounded ⟨_, ha⟩ in
+have hP0 : 0 < P, from lt_of_le_of_lt (abs_nonneg _) (hP 0),
+have hPε0 : 0 < ε / (2 * P),
+  from div_pos ε0 (mul_pos (show (2 : α) > 0, from by norm_num) hP0),
+let ⟨N, hN⟩ := cau_seq.cauchy₂ ⟨_, hb⟩ hPε0 in
+have hQε0 : 0 < ε / (4 * Q),
+  from div_pos ε0 (mul_pos (show (0 : α) < 4, by norm_num) (lt_of_le_of_lt (abv_nonneg _ _) (hQ 0))),
+let ⟨M, hM⟩ := cau_seq.cauchy₂ ⟨_, ha⟩ hQε0 in
+⟨2 * (max N M + 1), λ K hK,
+have h₁ : sum (range K) (λ m, (range (m + 1)).sum (λ k, a k * b (m - k))) =
+    sum (range K) (λ m, sum (range (K - m)) (λ n, a m * b n)),
+  by simpa using sum_range_diag_flip K (λ m n, a m * b n),
+have h₂ : (λ i, (range (K - i)).sum (λ k, a i * b k)) = (λ i, a i * (range (K - i)).sum b),
+  by simp [finset.mul_sum],
+have h₃ : (range K).sum (λ i, a i * (range (K - i)).sum b) =
+    (range K).sum (λ i, a i * ((range (K - i)).sum b - (range K).sum b))
+    + (range K).sum (λ i, a i * (range K).sum b),
+  by rw ← sum_add_distrib; simp [(mul_add _ _ _).symm],
+have two_mul_two : (4 : α) = 2 * 2, by norm_num,
+have hQ0 : Q ≠ 0, from λ h, by simpa [h, lt_irrefl] using hQε0,
+have h2Q0 : 2 * Q ≠ 0, from mul_ne_zero two_ne_zero hQ0,
+have hε : ε / (2 * P) * P + ε / (4 * Q) * (2 * Q) = ε,
+  by rw [← div_div_eq_div_mul, div_mul_cancel _ (ne.symm (ne_of_lt hP0)),
+    two_mul_two, mul_assoc, ← div_div_eq_div_mul, div_mul_cancel _ h2Q0, add_halves],
+have hNMK : max N M + 1 < K,
+  from lt_of_lt_of_le (by rw two_mul; exact lt_add_of_pos_left _ (nat.succ_pos _)) hK,
+have hKN : N < K,
+  from calc N ≤ max N M : le_max_left _ _
+  ... < max N M + 1 : nat.lt_succ_self _
+  ... < K : hNMK,
+have hsumlesum : (range (max N M + 1)).sum (λ i, abv (a i) *
+    abv ((range (K - i)).sum b - (range K).sum b)) ≤ (range (max N M + 1)).sum
+    (λ i, abv (a i) * (ε / (2 * P))),
+  from sum_le_sum (λ m hmJ, mul_le_mul_of_nonneg_left
+    (le_of_lt (hN (K - m) K
+      (nat.le_sub_left_of_add_le (le_trans
+        (by rw two_mul; exact add_le_add (le_of_lt (mem_range.1 hmJ))
+          (le_trans (le_max_left _ _) (le_of_lt (lt_add_one _)))) hK))
+      (le_of_lt hKN))) (abv_nonneg abv _)),
+have hsumltP : sum (range (max N M + 1)) (λ n, abv (a n)) < P :=
+  calc sum (range (max N M + 1)) (λ n, abv (a n))
+      = abs (sum (range (max N M + 1)) (λ n, abv (a n))) :
+  eq.symm (abs_of_nonneg (zero_le_sum (λ x h, abv_nonneg abv (a x))))
+  ... < P : hP (max N M + 1),
+begin
+  rw [h₁, h₂, h₃, sum_mul, ← sub_sub, sub_right_comm, sub_self, zero_sub, abv_neg abv],
+  refine lt_of_le_of_lt (abv_sum_le_sum_abv _ _) _,
+  suffices : (range (max N M + 1)).sum (λ (i : ℕ), abv (a i) * abv ((range (K - i)).sum b - (range K).sum b)) +
+    ((range K).sum (λ (i : ℕ), abv (a i) * abv ((range (K - i)).sum b - (range K).sum b)) -(range (max N M + 1)).sum
+     (λ (i : ℕ), abv (a i) * abv ((range (K - i)).sum b - (range K).sum b))) < ε / (2 * P) * P + ε / (4 * Q) * (2 * Q),
+  { rw hε at this, simpa [abv_mul abv] },
+  refine add_lt_add (lt_of_le_of_lt hsumlesum
+    (by rw [← sum_mul, mul_comm]; exact (mul_lt_mul_left hPε0).mpr hsumltP)) _,
+  rw sum_range_sub_sum_range (le_of_lt hNMK),
+  exact calc sum ((range K).filter (λ k, max N M + 1 ≤ k))
+      (λ i, abv (a i) * abv (sum (range (K - i)) b - sum (range K) b))
+      ≤ sum ((range K).filter (λ k, max N M + 1 ≤ k)) (λ i, abv (a i) * (2 * Q)) :
+    sum_le_sum (λ n hn, begin
+      refine mul_le_mul_of_nonneg_left _ (abv_nonneg _ _),
+      rw sub_eq_add_neg,
+      refine le_trans (abv_add _ _ _) _,
+      rw [two_mul, abv_neg abv],
+      exact add_le_add (le_of_lt (hQ _)) (le_of_lt (hQ _)),
+    end)
+    ... < ε / (4 * Q) * (2 * Q) :
+      by rw [← sum_mul, ← sum_range_sub_sum_range (le_of_lt hNMK)];
+      refine (mul_lt_mul_right $ by rw two_mul;
+        exact add_pos (lt_of_le_of_lt (abv_nonneg _ _) (hQ 0))
+          (lt_of_le_of_lt (abv_nonneg _ _) (hQ 0))).2
+        (lt_of_le_of_lt (le_abs_self _)
+          (hM _ _ (le_trans (nat.le_succ_of_le (le_max_right _ _)) (le_of_lt hNMK))
+            (nat.le_succ_of_le (le_max_right _ _))))
+end⟩
+
+end
+
+open finset
+
+namespace complex
+
+lemma is_cau_abs_exp (z : ℂ) : is_cau_seq _root_.abs
+  (λ n, (range n).sum (λ m, abs (z ^ m / nat.fact m))) :=
+let ⟨n, hn⟩ := exists_nat_gt (abs z) in
+have hn0 : (0 : ℝ) < n, from lt_of_le_of_lt (abs_nonneg _) hn,
+series_ratio_test n (complex.abs z / n) (div_nonneg_of_nonneg_of_pos (complex.abs_nonneg _) hn0)
+  (by rwa [div_lt_iff hn0, one_mul])
+  (λ m hm,
+    by rw [abs_abs, abs_abs, nat.fact_succ, pow_succ,
+      mul_comm m.succ, nat.cast_mul, ← div_div_eq_div_mul, mul_div_assoc,
+      mul_div_right_comm, abs_mul, abs_div, abs_cast_nat];
+    exact mul_le_mul_of_nonneg_right
+      (div_le_div_of_le_left (abs_nonneg _) (nat.cast_pos.2 (nat.succ_pos _)) hn0
+        (nat.cast_le.2 (le_trans hm (nat.le_succ _)))) (abs_nonneg _))
+
+noncomputable theory
+
+lemma is_cau_exp (z : ℂ) : is_cau_seq abs (λ n, (range n).sum (λ m, z ^ m / nat.fact m)) :=
+  is_cau_series_of_abv_cau (is_cau_abs_exp z)
+
+def exp' (z : ℂ) : cau_seq ℂ complex.abs := ⟨λ n, (range n).sum (λ m, z ^ m / nat.fact m), is_cau_exp z⟩
+
+def exp (z : ℂ) : ℂ := lim (exp' z)
+
+def sin (z : ℂ) : ℂ := ((exp (-z * I) - exp (z * I)) * I) / 2
+
+def cos (z : ℂ) : ℂ := (exp (z * I) + exp (-z * I)) / 2
+
+def tan (z : ℂ) : ℂ := sin z / cos z
+
+def sinh (z : ℂ) : ℂ := (exp z - exp (-z)) / 2
+
+def cosh (z : ℂ) : ℂ := (exp z + exp (-z)) / 2
+
+def tanh (z : ℂ) : ℂ := sinh z / cosh z
+
+end complex
+
+namespace real
+
+open complex
+
+def exp (x : ℝ) : ℝ := (exp x).re
+
+def sin (x : ℝ) : ℝ := (sin x).re
+
+def cos (x : ℝ) : ℝ := (cos x).re
+
+def tan (x : ℝ) : ℝ := (tan x).re
+
+def sinh (x : ℝ) : ℝ := (sinh x).re
+
+def cosh (x : ℝ) : ℝ := (cosh x).re
+
+def tanh (x : ℝ) : ℝ := (tanh x).re
+
+end real
+
+namespace complex
+
+variables (x y : ℂ)
+
+@[simp] lemma exp_zero : exp 0 = 1 :=
+lim_eq_of_equiv_const $
+  λ ε ε0, ⟨1, λ j hj, begin
+  convert ε0,
+  cases j,
+  { exact absurd hj (not_le_of_gt zero_lt_one) },
+  { dsimp [exp'],
+    induction j with j ih,
+    { dsimp [exp']; simp },
+    { rw ← ih dec_trivial,
+      simp only [sum_range_succ, pow_succ],
+      simp } }
+end⟩
+
+lemma exp_add : exp (x + y) = exp x * exp y :=
+show lim (⟨_, is_cau_exp (x + y)⟩ : cau_seq ℂ abs) =
+  lim (show cau_seq ℂ abs, from ⟨_, is_cau_exp x⟩)
+  * lim (show cau_seq ℂ abs, from ⟨_, is_cau_exp y⟩),
+from
+have hj : ∀ j : ℕ, (range j).sum
+    (λ m, (x + y) ^ m / m.fact) = (range j).sum
+    (λ i, (range (i + 1)).sum (λ k, x ^ k / k.fact *
+    (y ^ (i - k) / (i - k).fact))),
+  from assume j,
+    finset.sum_congr rfl (λ m hm, begin
+      rw [add_pow, div_eq_mul_inv, sum_mul],
+      refine finset.sum_congr rfl (λ i hi, _),
+      have h₁ : (choose m i : ℂ) ≠ 0 := nat.cast_ne_zero.2 (λ h,
+        by simpa [h, lt_irrefl] using choose_pos (nat.le_of_lt_succ (mem_range.1 hi))),
+      have h₂ := choose_mul_fact_mul_fact (nat.le_of_lt_succ $ finset.mem_range.1 hi),
+      rw [← h₂, nat.cast_mul, nat.cast_mul, mul_inv', mul_inv'],
+      simp only [mul_left_comm (choose m i : ℂ), mul_assoc, mul_left_comm (choose m i : ℂ)⁻¹,
+        mul_comm (choose m i : ℂ)],
+      rw inv_mul_cancel h₁,
+      simp [div_eq_mul_inv, mul_comm, mul_assoc, mul_left_comm]
+    end),
+by rw lim_mul_lim;
+  exact eq.symm (lim_eq_lim_of_equiv (by dsimp; simp only [hj];
+    exact cauchy_product (is_cau_abs_exp x) (is_cau_exp y)))
+
+lemma exp_ne_zero : exp x ≠ 0 :=
+λ h, @zero_ne_one ℂ _ $
+  by rw [← exp_zero, ← add_neg_self x, exp_add, h]; simp
+
+lemma exp_neg : exp (-x) = (exp x)⁻¹ :=
+by rw [← domain.mul_left_inj (exp_ne_zero x), ← exp_add];
+  simp [mul_inv_cancel (exp_ne_zero x)]
+
+lemma exp_sub : exp (x - y) = exp x / exp y :=
+by simp [exp_add, exp_neg, div_eq_mul_inv]
+
+@[simp] lemma exp_conj : exp (conj x) = conj (exp x) :=
+begin
+  dsimp [exp],
+  rw [← lim_conj],
+  refine congr_arg lim _,
+  dsimp [exp', function.comp],
+  funext,
+  rw ← sum_hom conj conj_zero conj_add,
+  refine sum_congr rfl (λ n hn, _),
+  rw [conj_div, conj_pow, ← of_real_nat_cast, conj_of_real]
+end
+
+@[simp] lemma exp_of_real_im (x : ℝ) : (exp x).im = 0 :=
+let ⟨r, hr⟩ := (eq_conj_iff_real (exp x)).1 (by rw [← exp_conj, conj_of_real]) in
+by rw [hr, of_real_im]
+
+lemma exp_of_real_re (x : ℝ) : (exp x).re = real.exp x := rfl
+
+@[simp] lemma of_real_exp_of_real_re (x : ℝ) : ((exp x).re : ℂ) = exp x :=
+complex.ext (by simp) (by simp)
+
+@[simp] lemma of_real_exp (x : ℝ) : (real.exp x : ℂ) = exp x :=
+complex.ext (by simp [real.exp]) (by simp [real.exp])
+
+@[simp] lemma sin_zero : sin 0 = 0 := by simp [sin]
+
+@[simp] lemma sin_neg : sin (-x) = -sin x :=
+by simp [sin, exp_neg, (neg_div _ _).symm, add_mul]
+
+lemma sin_add : sin (x + y) = sin x * cos y + cos x * sin y :=
+begin
+  rw [← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _),
+      ← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _)],
+  simp only [mul_add, add_mul, exp_add, div_mul_div, div_add_div_same,
+    mul_assoc, (div_div_eq_div_mul _ _ _).symm,
+    mul_div_cancel' _ (@two_ne_zero' ℂ _ _ _), sin, cos],
+  simp [mul_add, add_mul, exp_add],
+  ring
+end
+
+@[simp] lemma cos_zero : cos 0 = 1 := by simp [cos]
+
+@[simp] lemma cos_neg : cos (-x) = cos x :=
+by simp [cos, exp_neg]
+
+lemma cos_add : cos (x + y) = cos x * cos y - sin x * sin y :=
+begin
+  rw [← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _),
+      ← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _)],
+  simp only [mul_add, add_mul, mul_sub, sub_mul, exp_add, div_mul_div,
+    div_add_div_same, mul_assoc, (div_div_eq_div_mul _ _ _).symm,
+    mul_div_cancel' _ (@two_ne_zero' ℂ _ _ _), sin, cos],
+  apply complex.ext; simp [mul_add, add_mul, exp_add]; ring
+end
+
+lemma sin_sub : sin (x - y) = sin x * cos y - cos x * sin y :=
+by simp [sin_add, sin_neg, cos_neg]
+
+lemma cos_sub : cos (x - y) = cos x * cos y + sin x * sin y :=
+by simp [cos_add, sin_neg, cos_neg]
+
+lemma sin_conj : sin (conj x) = conj (sin x) :=
+begin
+  rw [sin, ← conj_neg_I, ← conj_mul, ← conj_neg, ← conj_mul,
+    exp_conj, exp_conj, ← conj_sub, sin, conj_div, conj_two,
+    ← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _),
+    mul_div_cancel' _ (@two_ne_zero' ℂ _ _ _),
+    mul_div_cancel' _ (@two_ne_zero' ℂ _ _ _)],
+  apply complex.ext; simp [sin, neg_add],
+end
+
+@[simp] lemma sin_of_real_im (x : ℝ) : (sin x).im = 0 :=
+let ⟨r, hr⟩ := (eq_conj_iff_real (sin x)).1 (by rw [← sin_conj, conj_of_real]) in
+by rw [hr, of_real_im]
+
+lemma sin_of_real_re (x : ℝ) : (sin x).re = real.sin x := rfl
+
+@[simp] lemma of_real_sin_of_real_re (x : ℝ) : ((sin x).re : ℂ) = sin x :=
+by apply complex.ext; simp
+
+@[simp] lemma of_real_sin (x : ℝ) : (real.sin x : ℂ) = sin x :=
+by simp [real.sin]
+
+lemma cos_conj : cos (conj x) = conj (cos x) :=
+begin
+  rw [cos, ← conj_neg_I, ← conj_mul, ← conj_neg, ← conj_mul,
+    exp_conj, exp_conj, cos, conj_div, conj_two,
+    ← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _),
+    mul_div_cancel' _ (@two_ne_zero' ℂ _ _ _),
+    mul_div_cancel' _ (@two_ne_zero' ℂ _ _ _)],
+  apply complex.ext; simp
+end
+
+@[simp] lemma cos_of_real_im (x : ℝ) : (cos x).im = 0 :=
+let ⟨r, hr⟩ := (eq_conj_iff_real (cos x)).1 (by rw [← cos_conj, conj_of_real]) in
+by rw [hr, of_real_im]
+
+lemma cos_of_real_re (x : ℝ) : (cos x).re = real.cos x := rfl
+
+@[simp] lemma of_real_cos_of_real_re (x : ℝ) : ((cos x).re : ℂ) = cos x :=
+by apply complex.ext; simp
+
+@[simp] lemma of_real_cos (x : ℝ) : (real.cos x : ℂ) = cos x :=
+by simp [real.cos, -cos_of_real_re]
+
+@[simp] lemma tan_zero : tan 0 = 0 := by simp [tan]
+
+lemma tan_eq_sin_div_cos : tan x = sin x / cos x := rfl
+
+@[simp] lemma tan_neg : tan (-x) = -tan x := by simp [tan, neg_div]
+
+lemma tan_conj : tan (conj x) = conj (tan x) :=
+by rw [tan, sin_conj, cos_conj, ← conj_div, tan]
+
+@[simp] lemma tan_of_real_im (x : ℝ) : (tan x).im = 0 :=
+let ⟨r, hr⟩ := (eq_conj_iff_real (tan x)).1 (by rw [← tan_conj, conj_of_real]) in
+by rw [hr, of_real_im]
+
+lemma tan_of_real_re (x : ℝ) : (tan x).re = real.tan x := rfl
+
+@[simp] lemma of_real_tan_of_real_re (x : ℝ) : ((tan x).re : ℂ) = tan x :=
+by apply complex.ext; simp
+
+@[simp] lemma of_real_tan (x : ℝ) : (real.tan x : ℂ) = tan x :=
+by simp [real.tan, -tan_of_real_re]
+
+lemma sin_pow_two_add_cos_pow_two : sin x ^ 2 + cos x ^ 2 = 1 :=
+begin
+  simp only [pow_two, mul_sub, sub_mul, mul_add, add_mul, div_eq_mul_inv,
+    neg_mul_eq_neg_mul_symm, exp_neg, mul_comm (exp _), mul_left_comm (exp _),
+    mul_assoc, mul_left_comm (exp _)⁻¹, inv_mul_cancel (exp_ne_zero _), mul_inv',
+    mul_one, one_mul, sin, cos],
+  apply complex.ext; simp [norm_sq]; ring
+end
+
+lemma cos_two_mul : cos (2 * x) = 2 * cos x ^ 2 - 1 :=
+by rw [two_mul, cos_add, ← pow_two, ← pow_two, eq_sub_iff_add_eq.2 (sin_pow_two_add_cos_pow_two x)];
+  simp [two_mul]
+
+lemma sin_two_mul : sin (2 * x) = 2 * sin x * cos x :=
+by rw [two_mul, sin_add, two_mul, add_mul, mul_comm]
+
+lemma exp_mul_I : exp (x * I) = cos x + sin x * I :=
+by rw [cos, sin, mul_comm (_ / 2) I, ← mul_div_assoc, mul_left_comm I, I_mul_I,
+  ← add_div]; simp
+
+lemma exp_add_mul_I : exp (x + y * I) = exp x * (cos y + sin y * I) :=
+by rw [exp_add, exp_mul_I]
+
+lemma exp_eq_exp_re_mul_sin_add_cos : exp x = exp x.re * (cos x.im + sin x.im * I) :=
+by rw [← exp_add_mul_I, re_add_im]
+
+@[simp] lemma sinh_zero : sinh 0 = 0 := by simp [sinh]
+
+@[simp] lemma sinh_neg : sinh (-x) = -sinh x :=
+by simp [sinh, exp_neg, (neg_div _ _).symm, add_mul]
+
+lemma sinh_add : sinh (x + y) = sinh x * cosh y + cosh x * sinh y :=
+begin
+  rw [← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _),
+      ← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _)],
+  simp only [mul_add, add_mul, exp_add, div_mul_div, div_add_div_same,
+    mul_assoc, (div_div_eq_div_mul _ _ _).symm,
+    mul_div_cancel' _ (@two_ne_zero' ℂ _ _ _), sinh, cosh],
+  simp [mul_add, add_mul, exp_add],
+  ring
+end
+
+@[simp] lemma cosh_zero : cosh 0 = 1 := by simp [cosh]
+
+@[simp] lemma cosh_neg : cosh (-x) = cosh x :=
+by simp [cosh, exp_neg]
+
+lemma cosh_add : cosh (x + y) = cosh x * cosh y + sinh x * sinh y :=
+begin
+  rw [← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _),
+      ← domain.mul_left_inj (@two_ne_zero' ℂ _ _ _)],
+  simp only [mul_add, add_mul, mul_sub, sub_mul, exp_add, div_mul_div,
+    div_add_div_same, mul_assoc, (div_div_eq_div_mul _ _ _).symm,
+    mul_div_cancel' _ (@two_ne_zero' ℂ _ _ _), sinh, cosh],
+  apply complex.ext; simp [mul_add, add_mul, exp_add]; ring
+end
+
+lemma sinh_sub : sinh (x - y) = sinh x * cosh y - cosh x * sinh y :=
+by simp [sinh_add, sinh_neg, cosh_neg]
+
+lemma cosh_sub : cosh (x - y) = cosh x * cosh y - sinh x * sinh y :=
+by simp [cosh_add, sinh_neg, cosh_neg]
+
+lemma sinh_conj : sinh (conj x) = conj (sinh x) :=
+by rw [sinh, ← conj_neg, exp_conj, exp_conj, ← conj_sub, sinh, conj_div, conj_two]
+
+@[simp] lemma sinh_of_real_im (x : ℝ) : (sinh x).im = 0 :=
+let ⟨r, hr⟩ := (eq_conj_iff_real (sinh x)).1 (by rw [← sinh_conj, conj_of_real]) in
+by rw [hr, of_real_im]
+
+lemma sinh_of_real_re (x : ℝ) : (sinh x).re = real.sinh x := rfl
+
+@[simp] lemma of_real_sinh_of_real_re (x : ℝ) : ((sinh x).re : ℂ) = sinh x :=
+by apply complex.ext; simp
+
+@[simp] lemma of_real_sinh (x : ℝ) : (real.sinh x : ℂ) = sinh x :=
+by simp [real.sinh]
+
+lemma cosh_conj : cosh (conj x) = conj (cosh x) :=
+by rw [cosh, ← conj_neg, exp_conj, exp_conj, ← conj_add, cosh, conj_div, conj_two]
+
+@[simp] lemma cosh_of_real_im (x : ℝ) : (cosh x).im = 0 :=
+let ⟨r, hr⟩ := (eq_conj_iff_real (cosh x)).1 (by rw [← cosh_conj, conj_of_real]) in
+by rw [hr, of_real_im]
+
+lemma cosh_of_real_re (x : ℝ) : (cosh x).re = real.cosh x := rfl
+
+@[simp] lemma of_real_cosh_of_real_re (x : ℝ) : ((cosh x).re : ℂ) = cosh x :=
+by apply complex.ext; simp
+
+@[simp] lemma of_real_cosh (x : ℝ) : (real.cosh x : ℂ) = cosh x :=
+by simp [real.cosh]
+
+lemma tanh_eq_sinh_div_cosh : tanh x = sinh x / cosh x := rfl
+
+@[simp] lemma tanh_zero : tanh 0 = 0 := by simp [tanh]
+
+@[simp] lemma tanh_neg : tanh (-x) = -tanh x := by simp [tanh, neg_div]
+
+lemma tanh_conj : tanh (conj x) = conj (tanh x) :=
+by rw [tanh, sinh_conj, cosh_conj, ← conj_div, tanh]
+
+@[simp] lemma tanh_of_real_im (x : ℝ) : (tanh x).im = 0 :=
+let ⟨r, hr⟩ := (eq_conj_iff_real (tanh x)).1 (by rw [← tanh_conj, conj_of_real]) in
+by rw [hr, of_real_im]
+
+lemma tanh_of_real_re (x : ℝ) : (tanh x).re = real.tanh x := rfl
+
+@[simp] lemma of_real_tanh_of_real_re (x : ℝ) : ((tanh x).re : ℂ) = tanh x :=
+by apply complex.ext; simp
+
+@[simp] lemma of_real_tanh (x : ℝ) : (real.tanh x : ℂ) = tanh x :=
+by simp [real.tanh]
+
+end complex
+
+namespace real
+
+open complex
+
+variables (x y : ℝ)
+
+@[simp] lemma exp_zero : exp 0 = 1 :=
+by simp [real.exp]
+
+lemma exp_add : exp (x + y) = exp x * exp y :=
+by simp [exp_add, exp]
+
+lemma exp_ne_zero : exp x ≠ 0 :=
+λ h, exp_ne_zero x $ by rw [exp, ← of_real_inj] at h; simp * at *
+
+lemma exp_neg : exp (-x) = (exp x)⁻¹ :=
+by rw [← of_real_inj, exp, of_real_exp_of_real_re, of_real_neg, exp_neg,
+  of_real_inv, of_real_exp]
+
+lemma exp_sub : exp (x - y) = exp x / exp y :=
+by simp [exp_add, exp_neg, div_eq_mul_inv]
+
+@[simp] lemma sin_zero : sin 0 = 0 := by simp [sin]
+
+@[simp] lemma sin_neg : sin (-x) = -sin x :=
+by simp [sin, exp_neg, (neg_div _ _).symm, add_mul]
+
+lemma sin_add : sin (x + y) = sin x * cos y + cos x * sin y :=
+by rw [← of_real_inj]; simp [sin, sin_add]
+
+@[simp] lemma cos_zero : cos 0 = 1 := by simp [cos]
+
+@[simp] lemma cos_neg : cos (-x) = cos x :=
+by simp [cos, exp_neg]
+
+lemma cos_add : cos (x + y) = cos x * cos y - sin x * sin y :=
+by rw ← of_real_inj; simp [cos, cos_add]
+
+lemma sin_sub : sin (x - y) = sin x * cos y - cos x * sin y :=
+by simp [sin_add, sin_neg, cos_neg]
+
+lemma cos_sub : cos (x - y) = cos x * cos y + sin x * sin y :=
+by simp [cos_add, sin_neg, cos_neg]
+
+lemma tan_eq_sin_div_cos : tan x = sin x / cos x :=
+if h : complex.cos x = 0 then by simp [sin, cos, tan, *, complex.tan, div_eq_mul_inv] at *
+else
+  by rw [sin, cos, tan, complex.tan, ← of_real_inj, div_eq_mul_inv, mul_re];
+  simp [norm_sq, (div_div_eq_div_mul _ _ _).symm, div_self h]; refl
+
+@[simp] lemma tan_zero : tan 0 = 0 := by simp [tan]
+
+@[simp] lemma tan_neg : tan (-x) = -tan x := by simp [tan, neg_div]
+
+lemma sin_pow_two_add_cos_pow_two : sin x ^ 2 + cos x ^ 2 = 1 :=
+by rw ← of_real_inj; simpa [sin, of_real_pow] using sin_pow_two_add_cos_pow_two x
+
+lemma abs_sin_le_one : abs' (sin x) ≤ 1 :=
+not_lt.1 $ λ h, lt_irrefl (1 * 1 : ℝ)
+  (calc 1 * 1 < abs' (sin x) * abs' (sin x) :
+      mul_lt_mul h (le_of_lt h) zero_lt_one (le_trans zero_le_one (le_of_lt h))
+    ... = sin x ^ 2 : by rw [← _root_.abs_mul, abs_mul_self, pow_two]
+    ... ≤ sin x ^ 2 + cos x ^ 2 : le_add_of_nonneg_right (pow_two_nonneg _)
+    ... = 1 * 1 : by rw [sin_pow_two_add_cos_pow_two, one_mul])
+
+lemma abs_cos_le_one : abs' (cos x) ≤ 1 :=
+not_lt.1 $ λ h, lt_irrefl (1 * 1 : ℝ)
+  (calc 1 * 1 < abs' (cos x) * abs' (cos x) :
+      mul_lt_mul h (le_of_lt h) zero_lt_one (le_trans zero_le_one (le_of_lt h))
+    ... = cos x ^ 2 : by rw [← _root_.abs_mul, abs_mul_self, pow_two]
+    ... ≤ sin x ^ 2 + cos x ^ 2 : le_add_of_nonneg_left (pow_two_nonneg _)
+    ... = 1 * 1 : by rw [sin_pow_two_add_cos_pow_two, one_mul])
+
+lemma sin_le_one : sin x ≤ 1 :=
+(abs_le.1 (abs_sin_le_one _)).2
+
+lemma cos_le_one : cos x ≤ 1 :=
+(abs_le.1 (abs_cos_le_one _)).2
+
+lemma neg_one_le_sin : -1 ≤ sin x :=
+(abs_le.1 (abs_sin_le_one _)).1
+
+lemma neg_one_le_cos : -1 ≤ cos x :=
+(abs_le.1 (abs_cos_le_one _)).1
+
+lemma sin_pow_two_le_one : sin x ^ 2 ≤ 1 :=
+by rw [pow_two, ← abs_mul_self, _root_.abs_mul];
+exact mul_le_one (abs_sin_le_one _) (abs_nonneg _) (abs_sin_le_one _)
+
+lemma cos_pow_two_le_one : cos x ^ 2 ≤ 1 :=
+by rw [pow_two, ← abs_mul_self, _root_.abs_mul];
+exact mul_le_one (abs_cos_le_one _) (abs_nonneg _) (abs_cos_le_one _)
+
+lemma cos_two_mul : cos (2 * x) = 2 * cos x ^ 2 - 1 :=
+by rw ← of_real_inj; simp [cos_two_mul, cos, pow_two]
+
+lemma sin_two_mul : sin (2 * x) = 2 * sin x * cos x :=
+by rw ← of_real_inj; simp [sin_two_mul, sin, pow_two]
+
+@[simp] lemma sinh_zero : sinh 0 = 0 := by simp [sinh]
+
+@[simp] lemma sinh_neg : sinh (-x) = -sinh x :=
+by simp [sinh, exp_neg, (neg_div _ _).symm, add_mul]
+
+lemma sinh_add : sinh (x + y) = sinh x * cosh y + cosh x * sinh y :=
+by rw ← of_real_inj; simp [sinh, sinh_add]
+
+@[simp] lemma cosh_zero : cosh 0 = 1 := by simp [cosh]
+
+@[simp] lemma cosh_neg : cosh (-x) = cosh x :=
+by simp [cosh, exp_neg]
+
+lemma cosh_add : cosh (x + y) = cosh x * cosh y + sinh x * sinh y :=
+by rw ← of_real_inj; simp [cosh, cosh_add]
+
+lemma sinh_sub : sinh (x - y) = sinh x * cosh y - cosh x * sinh y :=
+by simp [sinh_add, sinh_neg, cosh_neg]
+
+lemma cosh_sub : cosh (x - y) = cosh x * cosh y - sinh x * sinh y :=
+by simp [cosh_add, sinh_neg, cosh_neg]
+
+lemma tanh_eq_sinh_div_cosh : tanh x = sinh x / cosh x :=
+if h : complex.cosh x = 0 then by simp [sinh, cosh, tanh, *, complex.tanh, div_eq_mul_inv] at *
+else
+  by rw [sinh, cosh, tanh, complex.tanh, ← of_real_inj, div_eq_mul_inv, mul_re];
+  simp [norm_sq, (div_div_eq_div_mul _ _ _).symm, div_self h]; refl
+
+@[simp] lemma tanh_zero : tanh 0 = 0 := by simp [tanh]
+
+@[simp] lemma tanh_neg : tanh (-x) = -tanh x := by simp [tanh, neg_div]
+
+open is_absolute_value
+
+/- TODO make this private and prove ∀ x -/
+lemma add_one_le_exp_of_nonneg {x : ℝ} (hx : 0 ≤ x) : x + 1 ≤ exp x :=
+show x + 1 ≤ lim (⟨(λ n : ℕ, ((exp' x) n).re), is_cau_seq_re (exp' x)⟩ : cau_seq ℝ abs'),
+from real.le_lim (cau_seq.le_of_exists ⟨2,
+  λ j hj, show x + (1 : ℝ) ≤ ((range j).sum (λ m, (x ^ m / m.fact : ℂ))).re,
+    from have h₁ : (((λ m : ℕ, (x ^ m / m.fact : ℂ)) ∘ nat.succ) 0).re = x, by simp,
+    have h₂ : ((x : ℂ) ^ 0 / nat.fact 0).re = 1, by simp,
+    begin
+      rw [← nat.sub_add_cancel hj, sum_range_succ', sum_range_succ',
+        add_re, add_re, h₁, h₂, add_assoc, ← sum_hom complex.re zero_re add_re],
+      refine le_add_of_nonneg_of_le (zero_le_sum (λ m hm, _)) (le_refl _), dsimp [-nat.fact_succ],
+      rw [← of_real_pow, ← of_real_nat_cast, ← of_real_div, of_real_re],
+      exact div_nonneg (pow_nonneg hx _) (nat.cast_pos.2 (nat.fact_pos _)),
+    end⟩)
+
+lemma one_le_exp {x : ℝ} (hx : 0 ≤ x) : 1 ≤ exp x :=
+by linarith using [add_one_le_exp_of_nonneg hx]
+
+lemma exp_pos (x : ℝ) : 0 < exp x :=
+(le_total 0 x).elim (lt_of_lt_of_le zero_lt_one ∘ one_le_exp)
+  (λ h, by rw [← neg_neg x, real.exp_neg];
+    exact inv_pos (lt_of_lt_of_le zero_lt_one (one_le_exp (neg_nonneg.2 h))))
+
+@[simp] lemma abs_exp (x : ℝ) : abs' (exp x) = exp x :=
+abs_of_nonneg (le_of_lt (exp_pos _))
+
+lemma exp_le_exp {x y : ℝ} (h : x ≤ y) : exp x ≤ exp y :=
+by rw [← sub_add_cancel y x, real.exp_add];
+  exact (le_mul_iff_one_le_left (exp_pos _)).2 (one_le_exp (sub_nonneg.2 h))
+
+lemma exp_lt_exp {x y : ℝ} (h : x < y) : exp x < exp y :=
+by rw [← sub_add_cancel y x, real.exp_add];
+  exact (lt_mul_iff_one_lt_left (exp_pos _)).2
+    (lt_of_lt_of_le (by linarith) (add_one_le_exp_of_nonneg (by linarith)))
+
+lemma exp_injective : function.injective exp :=
+λ x y h, begin
+  rcases lt_trichotomy x y with h₁ | h₁ | h₁,
+  { exact absurd h (ne_of_lt (exp_lt_exp h₁)) },
+  { exact h₁ },
+  { exact absurd h (ne.symm (ne_of_lt (exp_lt_exp h₁))) }
+end
+
+end real
+
+namespace complex
+
+lemma sum_div_fact_le {α : Type*} [discrete_linear_ordered_field α] (n j : ℕ) (hn : 0 < n) :
+  (sum (filter (λ k, n ≤ k) (range j)) (λ m : ℕ, (1 / m.fact : α))) ≤ n.succ * (n.fact * n)⁻¹ :=
+calc (filter (λ k, n ≤ k) (range j)).sum (λ m : ℕ, (1 / m.fact : α))
+    = (range (j - n)).sum (λ m, 1 / (m + n).fact) :
+  sum_bij (λ m _, m - n)
+    (λ m hm, mem_range.2 $ (nat.sub_lt_sub_right_iff (by simp at hm; tauto)).2
+      (by simp at hm; tauto))
+    (λ m hm, by rw nat.sub_add_cancel; simp at *; tauto)
+    (λ a₁ a₂ ha₁ ha₂ h,
+      by rwa [nat.sub_eq_iff_eq_add, ← nat.sub_add_comm, eq_comm, nat.sub_eq_iff_eq_add, add_right_inj, eq_comm] at h;
+        simp at *; tauto)
+    (λ b hb, ⟨b + n, mem_filter.2 ⟨mem_range.2 $ nat.add_lt_of_lt_sub_right (mem_range.1 hb), nat.le_add_left _ _⟩,
+      by rw nat.add_sub_cancel⟩)
+... ≤ (range (j - n)).sum (λ m, (nat.fact n * n.succ ^ m)⁻¹) :
+  sum_le_sum (λ m hm, begin
+    rw one_div_eq_inv,
+    refine (inv_le_inv (nat.cast_pos.2 (nat.fact_pos _)) _).2 _,
+    { exact mul_pos (nat.cast_pos.2 (nat.fact_pos _)) (pow_pos (nat.cast_pos.2 (nat.succ_pos _)) _) },
+    { rw [← nat.cast_pow, ← nat.cast_mul, nat.cast_le, add_comm],
+      exact nat.fact_mul_pow_le_fact }
+  end)
+... = (nat.fact n)⁻¹ * (range (j - n)).sum (λ m, n.succ⁻¹ ^ m) :
+  by simp [mul_inv', mul_sum.symm, sum_mul.symm, -nat.fact_succ, mul_comm, inv_pow']
+... = (n.succ - n.succ * n.succ⁻¹ ^ (j - n)) / (n.fact * n) :
+  have h₁ : (n.succ : α) ≠ 1, from @nat.cast_one α _ _ ▸ mt nat.cast_inj.1
+        (mt nat.succ_inj (nat.pos_iff_ne_zero.1 hn)),
+  have h₂ : (n.succ : α) ≠ 0, from nat.cast_ne_zero.2 (nat.succ_ne_zero _),
+  have h₃ : (n.fact * n : α) ≠ 0, from mul_ne_zero (nat.cast_ne_zero.2 (nat.pos_iff_ne_zero.1 (nat.fact_pos _)))
+    (nat.cast_ne_zero.2 (nat.pos_iff_ne_zero.1 hn)),
+  have h₄ : (n.succ - 1 : α) * (n.fact : ℕ) ≠ 0,
+    from mul_ne_zero (sub_ne_zero.2 h₁)
+      (nat.cast_ne_zero.2 (nat.pos_iff_ne_zero.1 (nat.fact_pos _))),
+  by rw [geo_sum_inv_eq _ h₁ h₂, mul_comm, ← div_eq_mul_inv, div_div_eq_div_mul,
+      div_eq_div_iff h₄ h₃];
+    simp [mul_add, add_mul, mul_comm, mul_assoc, mul_left_comm]
+... ≤ n.succ / (n.fact * n) :
+  (div_le_div_right (mul_pos (nat.cast_pos.2 (nat.fact_pos _)) (nat.cast_pos.2 hn))).2
+    (sub_le_self _ (mul_nonneg (nat.cast_nonneg _) (pow_nonneg (inv_nonneg.2 (nat.cast_nonneg _)) _)))
+
+lemma exp_bound {x : ℂ} (hx : abs x ≤ 1) {n : ℕ} (hn : 0 < n) :
+  abs (exp x - (range n).sum (λ m, x ^ m / m.fact)) ≤ abs x ^ n * (n.succ * (n.fact * n)⁻¹) :=
+begin
+  rw [← lim_const ((range n).sum _), exp, sub_eq_add_neg, ← lim_neg, lim_add, ← lim_abs],
+  refine real.lim_le (cau_seq.le_of_exists ⟨n, λ j hj, _⟩),
+  show abs ((range j).sum (λ m, x ^ m / m.fact) - (range n).sum (λ m, x ^ m / m.fact))
+    ≤ abs x ^ n * (n.succ * (n.fact * n)⁻¹),
+  rw sum_range_sub_sum_range hj,
+  exact calc abs (((range j).filter (λ k, n ≤ k)).sum (λ m : ℕ, (x ^ m / m.fact : ℂ)))
+      = abs (((range j).filter (λ k, n ≤ k)).sum (λ m : ℕ, (x ^ n * (x ^ (m - n) / m.fact) : ℂ))) :
+    congr_arg abs (sum_congr rfl (λ m hm, by rw [← mul_div_assoc, ← pow_add, nat.add_sub_cancel']; simp at hm; tauto))
+  ... ≤ sum (filter (λ k, n ≤ k) (range j)) (λ m, abs (x ^ n * (_ / m.fact))) : abv_sum_le_sum_abv _ _
+  ... ≤ sum (filter (λ k, n ≤ k) (range j)) (λ m, abs x ^ n * (1 / m.fact)) :
+    sum_le_sum (λ m hm, by
+      by rw [abs_mul, abv_pow abs, abs_div, abs_cast_nat];
+      exact mul_le_mul_of_nonneg_left ((div_le_div_right (nat.cast_pos.2 (nat.fact_pos _))).2
+          (by rw abv_pow abs; exact (pow_le_one _ (abs_nonneg _) hx)))
+        (pow_nonneg (abs_nonneg _) _))
+  ... = abs x ^ n * (((range j).filter (λ k, n ≤ k)).sum (λ m : ℕ, (1 / m.fact : ℝ))) :
+    by simp [abs_mul, abv_pow abs, abs_div, mul_sum.symm]
+  ... ≤ abs x ^ n * (n.succ * (n.fact * n)⁻¹) :
+    mul_le_mul_of_nonneg_left (sum_div_fact_le _ _ hn) (pow_nonneg (abs_nonneg _) _)
+end
+
+lemma abs_exp_sub_one_le {x : ℂ} (hx : abs x ≤ 1) :
+  abs (exp x - 1) ≤ 2 * abs x :=
+calc abs (exp x - 1) = abs (exp x - (range 1).sum (λ m, x ^ m / m.fact)) :
+  by simp [sum_range_succ]
+... ≤ abs x ^ 1 * ((nat.succ 1) * (nat.fact 1 * 1)⁻¹) :
+  exp_bound hx dec_trivial
+... = 2 * abs x : by simp [two_mul, mul_two, mul_add, mul_comm]
+
+end complex
+
+namespace real
+
+open complex finset
+
+lemma cos_bound {x : ℝ} (hx : abs' x ≤ 1) : abs' (cos x - (1 - x ^ 2 / 2)) ≤ abs' x ^ 4 * (5 / 96) :=
+calc abs' (cos x - (1 - x ^ 2 / 2)) = abs (complex.cos x - (1 - x ^ 2 / 2)) :
+  by rw ← abs_of_real; simp [of_real_bit0, of_real_one, of_real_inv]
+... = abs ((complex.exp (x * I) + complex.exp (-x * I) - (2 - x ^ 2)) / 2) :
+  by simp [complex.cos, sub_div, add_div, neg_div, div_self (@two_ne_zero' ℂ _ _ _)]
+... = abs (((complex.exp (x * I) - (range 4).sum (λ m, (x * I) ^ m / m.fact)) +
+    ((complex.exp (-x * I) - (range 4).sum (λ m, (-x * I) ^ m / m.fact)))) / 2) :
+  congr_arg abs (congr_arg (λ x : ℂ, x / 2) begin
+    simp only [sum_range_succ],
+    simp [pow_succ],
+    apply complex.ext; simp [div_eq_mul_inv, norm_sq]; ring
+  end)
+... ≤ abs ((complex.exp (x * I) - (range 4).sum (λ m, (x * I) ^ m / m.fact)) / 2) +
+    abs ((complex.exp (-x * I) - (range 4).sum (λ m, (-x * I) ^ m / m.fact)) / 2) :
+  by rw add_div; exact abs_add _ _
+... = (abs ((complex.exp (x * I) - (range 4).sum (λ m, (x * I) ^ m / m.fact))) / 2 +
+    abs ((complex.exp (-x * I) - (range 4).sum (λ m, (-x * I) ^ m / m.fact))) / 2) :
+  by simp [complex.abs_div]
+... ≤ ((complex.abs (x * I) ^ 4 * (nat.succ 4 * (nat.fact 4 * (4 : ℕ))⁻¹)) / 2 +
+    (complex.abs (-x * I) ^ 4 * (nat.succ 4 * (nat.fact 4 * (4 : ℕ))⁻¹)) / 2)  :
+  add_le_add ((div_le_div_right (by norm_num)).2 (exp_bound (by simpa) dec_trivial))
+             ((div_le_div_right (by norm_num)).2 (exp_bound (by simpa) dec_trivial))
+... ≤ abs' x ^ 4 * (5 / 96) : by norm_num; simp [mul_assoc, mul_comm, mul_left_comm, mul_div_assoc]
+
+lemma sin_bound {x : ℝ} (hx : abs' x ≤ 1) : abs' (sin x - (x - x ^ 3 / 6)) ≤ abs' x ^ 4 * (5 / 96) :=
+calc abs' (sin x - (x - x ^ 3 / 6)) = abs (complex.sin x - (x - x ^ 3 / 6)) :
+  by rw ← abs_of_real; simp [of_real_bit0, of_real_one, of_real_inv]
+... = abs (((complex.exp (-x * I) - complex.exp (x * I)) * I - (2 * x - x ^ 3 / 3)) / 2) :
+  by simp [complex.sin, sub_div, add_div, neg_div, mul_div_cancel_left _ (@two_ne_zero' ℂ _ _ _),
+    div_div_eq_div_mul, show (3 : ℂ) * 2 = 6, by norm_num]
+... = abs ((((complex.exp (-x * I) - (range 4).sum (λ m, (-x * I) ^ m / m.fact)) -
+    (complex.exp (x * I) - (range 4).sum (λ m, (x * I) ^ m / m.fact))) * I) / 2) :
+  congr_arg abs (congr_arg (λ x : ℂ, x / 2) begin
+    simp only [sum_range_succ],
+    simp [pow_succ],
+    apply complex.ext; simp [div_eq_mul_inv, norm_sq]; ring
+  end)
+... ≤ abs ((complex.exp (-x * I) - (range 4).sum (λ m, (-x * I) ^ m / m.fact)) * I / 2) +
+    abs (-((complex.exp (x * I) - (range 4).sum (λ m, (x * I) ^ m / m.fact)) * I) / 2) :
+  by rw [sub_mul, sub_eq_add_neg, add_div]; exact abs_add _ _
+... = (abs ((complex.exp (x * I) - (range 4).sum (λ m, (x * I) ^ m / m.fact))) / 2 +
+    abs ((complex.exp (-x * I) - (range 4).sum (λ m, (-x * I) ^ m / m.fact))) / 2) :
+  by simp [complex.abs_div, complex.abs_mul]
+... ≤ ((complex.abs (x * I) ^ 4 * (nat.succ 4 * (nat.fact 4 * (4 : ℕ))⁻¹)) / 2 +
+    (complex.abs (-x * I) ^ 4 * (nat.succ 4 * (nat.fact 4 * (4 : ℕ))⁻¹)) / 2) :
+  add_le_add ((div_le_div_right (by norm_num)).2 (exp_bound (by simpa) dec_trivial))
+             ((div_le_div_right (by norm_num)).2 (exp_bound (by simpa) dec_trivial))
+... ≤ abs' x ^ 4 * (5 / 96) : by norm_num; simp [mul_assoc, mul_comm, mul_left_comm, mul_div_assoc]
+
+lemma cos_pos_of_le_one {x : ℝ} (hx : abs' x ≤ 1) : 0 < cos x :=
+calc 0 < (1 - x ^ 2 / 2) - abs' x ^ 4 * (5 / 96) :
+  sub_pos.2 $ lt_sub_iff_add_lt.2
+    (calc abs' x ^ 4 * (5 / 96) + x ^ 2 / 2
+          ≤ 1 * (5 / 96) + 1 / 2 :
+        add_le_add
+          (mul_le_mul_of_nonneg_right (pow_le_one _ (abs_nonneg _) hx) (by norm_num))
+          ((div_le_div_right (by norm_num)).2 (by rw [pow_two, ← abs_mul_self, _root_.abs_mul];
+            exact mul_le_one hx (abs_nonneg _) hx))
+      ... < 1 : by norm_num)
+... ≤ cos x : sub_le.1 (abs_sub_le_iff.1 (cos_bound hx)).2
+
+lemma sin_pos_of_pos_of_le_one {x : ℝ} (hx0 : 0 < x) (hx : x ≤ 1) : 0 < sin x :=
+calc 0 < x - x ^ 3 / 6 - abs' x ^ 4 * (5 / 96) :
+  sub_pos.2 $ lt_sub_iff_add_lt.2
+    (calc abs' x ^ 4 * (5 / 96) + x ^ 3 / 6
+        ≤ x * (5 / 96) + x / 6 :
+      add_le_add
+        (mul_le_mul_of_nonneg_right
+          (calc abs' x ^ 4 ≤ abs' x ^ 1 : pow_le_pow_of_le_one (abs_nonneg _)
+                (by rwa _root_.abs_of_nonneg (le_of_lt hx0))
+                dec_trivial
+            ... = x : by simp [_root_.abs_of_nonneg (le_of_lt (hx0))]) (by norm_num))
+        ((div_le_div_right (by norm_num)).2
+          (calc x ^ 3 ≤ x ^ 1 : pow_le_pow_of_le_one (le_of_lt hx0) hx dec_trivial
+            ... = x : pow_one _))
+    ... < x : by linarith)
+... ≤ sin x : sub_le.1 (abs_sub_le_iff.1 (sin_bound
+    (by rwa [_root_.abs_of_nonneg (le_of_lt hx0)]))).2
+
+lemma sin_pos_of_pos_of_le_two {x : ℝ} (hx0 : 0 < x) (hx : x ≤ 2) : 0 < sin x :=
+have x / 2 ≤ 1, from div_le_of_le_mul (by norm_num) (by simpa),
+calc 0 < 2 * sin (x / 2) * cos (x / 2) :
+  mul_pos (mul_pos (by norm_num) (sin_pos_of_pos_of_le_one (half_pos hx0) this))
+    (cos_pos_of_le_one (by rwa [_root_.abs_of_nonneg (le_of_lt (half_pos hx0))]))
+... = sin x : by rw [← sin_two_mul, two_mul, add_halves]
+
+lemma cos_one_le : cos 1 ≤ 2 / 3 :=
+calc cos 1 ≤ abs' (1 : ℝ) ^ 4 * (5 / 96) + (1 - 1 ^ 2 / 2) :
+  sub_le_iff_le_add.1 (abs_sub_le_iff.1 (cos_bound (by simp))).1
+... ≤ 2 / 3 : by norm_num
+
+lemma cos_one_pos : 0 < cos 1 := cos_pos_of_le_one (by simp)
+
+lemma cos_two_neg : cos 2 < 0 :=
+calc cos 2 = cos (2 * 1) : congr_arg cos (mul_one _).symm
+... = _ : real.cos_two_mul 1
+... ≤ 2 * (2 / 3) ^ 2 - 1 :
+  sub_le_sub_right (mul_le_mul_of_nonneg_left
+    (by rw [pow_two, pow_two]; exact
+      mul_self_le_mul_self (le_of_lt cos_one_pos)
+        cos_one_le)
+    (by norm_num)) _
+... < 0 : by norm_num
+
+end real
+
+namespace complex
+
+lemma abs_cos_add_sin_mul_I (x : ℝ) : abs (cos x + sin x * I) = 1 :=
+have _ := real.sin_pow_two_add_cos_pow_two x,
+by simp [abs, norm_sq, pow_two, *, sin_of_real_re, cos_of_real_re, mul_re] at *
+
+lemma abs_exp_eq_iff_re_eq {x y : ℂ} : abs (exp x) = abs (exp y) ↔ x.re = y.re :=
+by rw [exp_eq_exp_re_mul_sin_add_cos, exp_eq_exp_re_mul_sin_add_cos y,
+    abs_mul, abs_mul, abs_cos_add_sin_mul_I, abs_cos_add_sin_mul_I,
+    ← of_real_exp, ← of_real_exp, abs_of_nonneg (le_of_lt (real.exp_pos _)),
+    abs_of_nonneg (le_of_lt (real.exp_pos _)), mul_one, mul_one];
+  exact ⟨λ h, real.exp_injective h, congr_arg _⟩
+
+@[simp] lemma abs_exp_of_real (x : ℝ) : abs (exp x) = real.exp x :=
+by rw [← of_real_exp]; exact abs_of_nonneg (le_of_lt (real.exp_pos _))
+
+end complex

--- a/data/int/basic.lean
+++ b/data/int/basic.lean
@@ -438,6 +438,16 @@ by have := mod_add_div a b; rwa [H, zero_add] at this
 theorem div_mul_cancel_of_mod_eq_zero {a b : ℤ} (H : a % b = 0) : a / b * b = a :=
 by rw [mul_comm, mul_div_cancel_of_mod_eq_zero H]
 
+lemma mod_two_eq_zero_or_one (n : ℤ) : n % 2 = 0 ∨ n % 2 = 1 :=
+have h : n % 2 < 2 := abs_of_nonneg (show (2 : ℤ) ≥ 0, from dec_trivial) ▸ int.mod_lt _ dec_trivial,
+have h₁ : n % 2 ≥ 0 := int.mod_nonneg _ dec_trivial,
+match (n % 2), h, h₁ with
+| (0 : ℕ) := λ _ _, or.inl rfl
+| (1 : ℕ) := λ _ _, or.inr rfl
+| (k + 2 : ℕ) := λ h _, absurd h dec_trivial
+| -[1+ a] := λ _ h₁, absurd h₁ dec_trivial
+end
+
 /- dvd -/
 
 theorem coe_nat_dvd {m n : ℕ} : (↑m : ℤ) ∣ ↑n ↔ m ∣ n :=
@@ -1067,6 +1077,8 @@ by cases n; simp [nat.mul_cast_comm, left_distrib, right_distrib, *]
 
 @[simp] theorem cast_bit1 [ring α] (n : ℤ) : ((bit1 n : ℤ) : α) = bit1 n :=
 by rw [bit1, cast_add, cast_one, cast_bit0]; refl
+
+lemma cast_two [ring α] : ((2 : ℤ) : α) = 2 := by simp
 
 theorem cast_nonneg [linear_ordered_ring α] : ∀ {n : ℤ}, (0 : α) ≤ n ↔ 0 ≤ n
 | (n : ℕ) := by simp

--- a/data/nat/basic.lean
+++ b/data/nat/basic.lean
@@ -681,6 +681,13 @@ theorem dvd_fact : ∀ {m n}, m > 0 → m ≤ n → m ∣ fact n
 theorem fact_le {m n} (h : m ≤ n) : fact m ≤ fact n :=
 le_of_dvd (fact_pos _) (fact_dvd_fact h)
 
+lemma fact_mul_pow_le_fact : ∀ {m n : ℕ}, m.fact * m.succ ^ n ≤ (m + n).fact
+| m 0     := by simp
+| m (n+1) :=
+by  rw [← add_assoc, nat.fact_succ, mul_comm (nat.succ _), nat.pow_succ, ← mul_assoc];
+  exact mul_le_mul fact_mul_pow_le_fact
+    (nat.succ_le_succ (nat.le_add_right _ _)) (nat.zero_le _) (nat.zero_le _)
+
 section find_greatest
 
 /-- `find_greatest P b` is the largest `i ≤ bound` such that `P i` holds, or `0` if no such `i`

--- a/data/nat/cast.lean
+++ b/data/nat/cast.lean
@@ -37,6 +37,8 @@ end
 @[simp] theorem cast_bit1 [add_monoid α] [has_one α] (n : ℕ) : ((bit1 n : ℕ) : α) = bit1 n :=
 by rw [bit1, cast_add_one, cast_bit0]; refl
 
+lemma cast_two {α : Type*} [semiring α] : ((2 : ℕ) : α) = 2 := by simp
+
 @[simp] theorem cast_pred [add_group α] [has_one α] : ∀ {n}, n > 0 → ((n - 1 : ℕ) : α) = n - 1
 | (n+1) h := (add_sub_cancel (n:α) 1).symm
 

--- a/data/real/basic.lean
+++ b/data/real/basic.lean
@@ -440,6 +440,22 @@ lim_eq_of_equiv_const $ show lim_zero (inv f hf - const abs (lim ⇑f)⁻¹),
       (by rw [← mul_assoc]; exact h₁ _ _ _),
   (lim_zero_congr h₂).mpr $ by rw mul_comm; exact mul_lim_zero _ (setoid.symm (equiv_lim f))
 
+lemma lim_le {f : cau_seq ℝ abs} {x : ℝ}
+  (h : f ≤ cau_seq.const abs x) : real.lim f ≤ x :=
+cau_seq.const_le.1 $ cau_seq.le_of_eq_of_le (setoid.symm (real.equiv_lim f)) h
+
+lemma le_lim {f : cau_seq ℝ abs} {x : ℝ}
+  (h : cau_seq.const abs x ≤ f) : x ≤ real.lim f :=
+cau_seq.const_le.1 $ cau_seq.le_of_le_of_eq h (real.equiv_lim f)
+
+lemma lt_lim {f : cau_seq ℝ abs} {x : ℝ}
+  (h : cau_seq.const abs x < f) : x < real.lim f :=
+cau_seq.const_lt.1 $ cau_seq.lt_of_lt_of_eq h (real.equiv_lim f)
+
+lemma lim_lt {f : cau_seq ℝ abs} {x : ℝ}
+  (h : f < cau_seq.const abs x) : real.lim f < x :=
+cau_seq.const_lt.1 $ cau_seq.lt_of_eq_of_lt (setoid.symm (real.equiv_lim f)) h
+
 end lim
 
 theorem sqrt_exists : ∀ {x : ℝ}, 0 ≤ x → ∃ y, 0 ≤ y ∧ y * y = x :=


### PR DESCRIPTION
…, tanh, pi, arcsin, argcos, arg (#386)

* `floor_ring` now is parameterized on a `linear_ordered_ring` instead of extending it.
*

TO CONTRIBUTORS:

Make sure you have:

 * [ ] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
