### PR TITLE
make some category arguments implicit

### DIFF
--- a/category_theory/const.lean
+++ b/category_theory/const.lean
@@ -12,7 +12,7 @@ open category_theory
 namespace category_theory.functor
 
 variables (J : Type v) [small_category J]
-variables (C : Type u) [𝒞 : category.{u v} C]
+variables {C : Type u} [𝒞 : category.{u v} C]
 include 𝒞
 
 def const : C ⥤ (J ⥤ C) :=
@@ -22,9 +22,9 @@ def const : C ⥤ (J ⥤ C) :=
   map := λ X Y f, { app := λ j, f } }
 
 namespace const
-@[simp] lemma obj_obj (X : C) (j : J) : ((const J C).obj X).obj j = X := rfl
-@[simp] lemma obj_map (X : C) {j j' : J} (f : j ⟶ j') : ((const J C).obj X).map f = 𝟙 X := rfl
-@[simp] lemma map_app {X Y : C} (f : X ⟶ Y) (j : J) : ((const J C).map f).app j = f := rfl
+@[simp] lemma obj_obj (X : C) (j : J) : ((const J).obj X).obj j = X := rfl
+@[simp] lemma obj_map (X : C) {j j' : J} (f : j ⟶ j') : ((const J).obj X).map f = 𝟙 X := rfl
+@[simp] lemma map_app {X Y : C} (f : X ⟶ Y) (j : J) : ((const J).map f).app j = f := rfl
 end const
 
 variables (J) {C}
@@ -34,7 +34,7 @@ variables {D : Type u'} [𝒟 : category.{u' v} D]
 include 𝒟
 
 @[simp] def const_compose (X : C) (F : C ⥤ D) : 
-  (const J D).obj (F.obj X) ≅ (const J C).obj X ⋙ F :=
+  (const J).obj (F.obj X) ≅ (const J).obj X ⋙ F :=
 { hom := { app := λ _, 𝟙 _ },
   inv := { app := λ _, 𝟙 _ } }
 
@@ -52,6 +52,6 @@ natural transformations from the constant functor with value `X` to `F`.
 `cone F` is equivalent, in the obvious way, to `Σ X, F.cones X`.
 -/
 def cones (F : J ⥤ C) : (Cᵒᵖ) ⥤ (Type v) :=
-  (const (Jᵒᵖ) (Cᵒᵖ)) ⋙ (op_inv J C) ⋙ ((yoneda (J ⥤ C)).obj F)
+  (const (Jᵒᵖ)) ⋙ (op_inv J C) ⋙ ((yoneda (J ⥤ C)).obj F)
 
 end category_theory.functor

--- a/category_theory/const.lean
+++ b/category_theory/const.lean
@@ -52,6 +52,6 @@ natural transformations from the constant functor with value `X` to `F`.
 `cone F` is equivalent, in the obvious way, to `Σ X, F.cones X`.
 -/
 def cones (F : J ⥤ C) : (Cᵒᵖ) ⥤ (Type v) :=
-  (const (Jᵒᵖ)) ⋙ (op_inv J C) ⋙ ((yoneda (J ⥤ C)).obj F)
+  (const (Jᵒᵖ)) ⋙ (op_inv J C) ⋙ (yoneda.obj F)
 
 end category_theory.functor

--- a/category_theory/limits/cones.lean
+++ b/category_theory/limits/cones.lean
@@ -70,8 +70,7 @@ def cone_of_cones {X : C} (π : F.cones.obj X) : cone F :=
 end functor
 
 namespace cone
-@[simp] def extensions (c : cone F) :
-  (yoneda C).obj c.X ⟶ F.cones :=
+@[simp] def extensions (c : cone F) : yoneda.obj c.X ⟶ F.cones :=
 { app := λ X f, ((const J).map f) ⊟ c.π }
 
 @[simp] def extend (c : cone F) {X : C} (f : X ⟶ c.X) : cone F :=

--- a/category_theory/limits/cones.lean
+++ b/category_theory/limits/cones.lean
@@ -28,7 +28,7 @@ A `c : cone F` is:
 -/
 structure cone (F : J ⥤ C) :=
 (X : C)
-(π : (const J C).obj X ⟹ F)
+(π : (const J).obj X ⟹ F)
 
 @[simp] lemma cone.w {F : J ⥤ C} (c : cone F) {j j' : J} (f : j ⟶ j') :
   c.π.app j ≫ F.map f = c.π.app j' :=
@@ -46,7 +46,7 @@ A `c : cocone F` is
 -/
 structure cocone (F : J ⥤ C) :=
 (X : C)
-(ι : F ⟹ (const J C).obj X)
+(ι : F ⟹ (const J).obj X)
 
 @[simp] lemma cocone.w {F : J ⥤ C} (c : cocone F) {j j' : J} (f : j ⟶ j') :
   F.map f ≫ c.ι.app j' = c.ι.app j :=
@@ -72,7 +72,7 @@ end functor
 namespace cone
 @[simp] def extensions (c : cone F) :
   (yoneda C).obj c.X ⟶ F.cones :=
-{ app := λ X f, ((const J C).map f) ⊟ c.π }
+{ app := λ X f, ((const J).map f) ⊟ c.π }
 
 @[simp] def extend (c : cone F) {X : C} (f : X ⟶ c.X) : cone F :=
 { X := X,
@@ -93,7 +93,7 @@ end cone
 namespace cocone
 def extend (c : cocone F) {X : C} (f : c.X ⟶ X) : cocone F :=
 { X := X,
-  ι := c.ι ⊟ (const J C).map f }
+  ι := c.ι ⊟ (const J).map f }
 
 def precompose {G : J ⥤ C} (c : cocone F) (α : G ⟹ F) : cocone G :=
 { X := c.X,

--- a/category_theory/limits/limits.lean
+++ b/category_theory/limits/limits.lean
@@ -117,7 +117,7 @@ def is_limit.of_lift_universal
   fac'  := λ s j, ((universal s (lift s)).mpr (eq.refl (lift s))) j,
   uniq' := λ s φ, (universal s φ).mp }
 
-def is_limit.equiv (h : is_limit t) (X' : C) : (X' ⟶ t.X) ≅ ((functor.const J C).obj X' ⟹ F) :=
+def is_limit.equiv (h : is_limit t) (X' : C) : (X' ⟶ t.X) ≅ ((functor.const J).obj X' ⟹ F) :=
 { hom := λ f, (t.extend f).π,
   inv := λ π, h.lift { X := X', π := π },
   hom_inv_id' :=
@@ -143,7 +143,7 @@ def is_limit.of_extensions_iso (h : is_iso t.extensions) : is_limit t :=
     have : m = (t.extensions ≫ inv t.extensions).app s.X m,
       by erw @is_iso.hom_inv_id _ _ _ _ _ h; refl,
     rw this,
-    have : s.π = (functor.const J C).map m ≫ t.π, by ext j; exact (hm j).symm,
+    have : s.π = (functor.const J).map m ≫ t.π, by ext j; exact (hm j).symm,
     rw this,
     refl
   end }

--- a/category_theory/limits/limits.lean
+++ b/category_theory/limits/limits.lean
@@ -130,8 +130,7 @@ def is_limit.equiv (h : is_limit t) (X' : C) : (X' ⟶ t.X) ≅ ((functor.const 
 @[simp] lemma is_limit.equiv_hom (h : is_limit t) (X' : C) (f : X' ⟶ t.X) :
   (is_limit.equiv h X').hom f = (t.extend f).π := rfl
 
-def is_limit.natural_equiv (h : is_limit t) :
-  (yoneda C).obj t.X ≅ F.cones :=
+def is_limit.natural_equiv (h : is_limit t) : yoneda.obj t.X ≅ F.cones :=
 nat_iso.of_components (is_limit.equiv h) (by tidy)
 
 def is_limit.of_extensions_iso (h : is_iso t.extensions) : is_limit t :=
@@ -174,7 +173,7 @@ lemma cone.of_representable_cones_extension (F : J ⥤ C) (r : representable F.c
   (cone.of_representable_cones F).extensions = r.w.hom :=
 begin
   ext1 Z, ext1 f,
-  have : (((yoneda C).obj r.X).map f ≫ r.w.hom.app  Z) (𝟙 _) = _, by rw [r.w.hom.naturality f],
+  have : ((yoneda.obj r.X).map f ≫ r.w.hom.app  Z) (𝟙 _) = _, by rw [r.w.hom.naturality f],
   simpa using this.symm
 end
 

--- a/category_theory/yoneda.lean
+++ b/category_theory/yoneda.lean
@@ -17,7 +17,7 @@ namespace category_theory
 
 universes u₁ v₁ u₂
 
-variables (C : Type u₁) [𝒞 : category.{u₁ v₁} C]
+variables {C : Type u₁} [𝒞 : category.{u₁ v₁} C]
 include 𝒞
 
 def yoneda : C ⥤ ((Cᵒᵖ) ⥤ (Type v₁)) :=
@@ -28,22 +28,24 @@ def yoneda : C ⥤ ((Cᵒᵖ) ⥤ (Type v₁)) :=
     map_id' := begin intros X_1, ext1, dsimp at *, erw [category.id_comp] end },
   map := λ X X' f, { app := λ Y g, g ≫ f } }
 
-namespace yoneda
-@[simp] lemma obj_obj (X Y : C) : ((yoneda C).obj X).obj Y = (Y ⟶ X) := rfl
-@[simp] lemma obj_map (X : C) {Y Y' : C} (f : Y ⟶ Y') : ((yoneda C).obj X).map f = λ g, f ≫ g := rfl
-@[simp] lemma map_app {X X' : C} (f : X ⟶ X') (Y : C) : ((yoneda C).map f).app Y = λ g, g ≫ f := rfl
+variables (C)
 
-lemma obj_map_id {X Y : Cᵒᵖ} (f : X ⟶ Y) : ((yoneda C).obj X).map f (𝟙 X) = ((yoneda C).map f).app Y (𝟙 Y) :=
+namespace yoneda
+@[simp] lemma obj_obj (X Y : C) : (yoneda.obj X).obj Y = (Y ⟶ X) := rfl
+@[simp] lemma obj_map (X : C) {Y Y' : C} (f : Y ⟶ Y') : (yoneda.obj X).map f = λ g, f ≫ g := rfl
+@[simp] lemma map_app {X X' : C} (f : X ⟶ X') (Y : C) : (yoneda.map f).app Y = λ g, g ≫ f := rfl
+
+lemma obj_map_id {X Y : Cᵒᵖ} (f : X ⟶ Y) : ((@yoneda C _).obj X).map f (𝟙 X) = ((@yoneda C _).map f).app Y (𝟙 Y) :=
 by obviously
 
-@[simp] lemma naturality {X Y : C} (α : (yoneda C).obj X ⟶ (yoneda C).obj Y)
+@[simp] lemma naturality {X Y : C} (α : yoneda.obj X ⟶ yoneda.obj Y)
   {Z Z' : C} (f : Z ⟶ Z') (h : Z' ⟶ X) : f ≫ α.app Z' h = α.app Z (f ≫ h) :=
 begin erw [functor_to_types.naturality], refl end
 
-instance yoneda_full : full (yoneda C) :=
+instance yoneda_full : full (@yoneda C _) :=
 { preimage := λ X Y f, (f.app X) (𝟙 X) }.
 
-instance yoneda_faithful : faithful (yoneda C) :=
+instance yoneda_faithful : faithful (@yoneda C _) :=
 begin
   fsplit,
   intros X Y f g p,
@@ -63,7 +65,7 @@ def ext (X Y : C)
   (p : Π {Z : C}, (Z ⟶ X) → (Z ⟶ Y)) (q : Π {Z : C}, (Z ⟶ Y) → (Z ⟶ X))
   (h₁ : Π {Z : C} (f : Z ⟶ X), q (p f) = f) (h₂ : Π {Z : C} (f : Z ⟶ Y), p (q f) = f)
   (n : Π {Z Z' : C} (f : Z' ⟶ Z) (g : Z ⟶ X), p (f ≫ g) = f ≫ p g) : X ≅ Y :=
-@preimage_iso _ _ _ _ (yoneda C) _ _ _ _
+@preimage_iso _ _ _ _ yoneda _ _ _ _
   (nat_iso.of_components (λ Z, { hom := p, inv := q, }) (by tidy))
 
 -- We need to help typeclass inference with some awkward universe levels here.
@@ -85,12 +87,12 @@ def yoneda_evaluation : ((Cᵒᵖ) × ((Cᵒᵖ) ⥤ (Type v₁))) ⥤ (Type (ma
   ((yoneda_evaluation C).map α x).down = (α.2).app (Q.1) ((P.2).map (α.1) (x.down)) := rfl
 
 def yoneda_pairing : ((Cᵒᵖ) × ((Cᵒᵖ) ⥤ (Type v₁))) ⥤ (Type (max u₁ v₁)) :=
-(functor.prod ((yoneda C).op) (functor.id ((Cᵒᵖ) ⥤ (Type v₁)))) ⋙
+(functor.prod (yoneda.op) (functor.id ((Cᵒᵖ) ⥤ (Type v₁)))) ⋙
   (functor.hom ((Cᵒᵖ) ⥤ (Type v₁)))
 
 @[simp] lemma yoneda_pairing_map
   (P Q : (Cᵒᵖ) × (Cᵒᵖ ⥤ Type v₁)) (α : P ⟶ Q) (β : (yoneda_pairing C).obj P) :
-  (yoneda_pairing C).map α β = (yoneda C).map (α.1) ≫ β ≫ α.2 := rfl
+  (yoneda_pairing C).map α β = yoneda.map (α.1) ≫ β ≫ α.2 := rfl
 
 def yoneda_lemma : (yoneda_pairing C) ≅ (yoneda_evaluation C) :=
 { hom :=
@@ -142,6 +144,6 @@ variables {C}
 
 class representable (F : Cᵒᵖ ⥤ Type v₁) :=
 (X : C)
-(w : (yoneda C).obj X ≅ F)
+(w : yoneda.obj X ≅ F)
 
 end category_theory


### PR DESCRIPTION
This is another advantage of eliminating coercions--these arguments of `const` and `yoneda` are almost always obvious, but the way coercions worked meant that we still couldn't omit them.